### PR TITLE
Add step for renaming plates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+
+# Settings for pycharm (covid project), in order to be able to share run configurations
+.idea/*
+.idea/*/
+!.idea/runConfigurations

--- a/.idea/runConfigurations/covid_rename_plates.xml
+++ b/.idea/runConfigurations/covid_rename_plates.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="covid.rename_plates" type="PythonConfigurationType" factoryName="Python" folderName="covid">
+    <module name="claritylims" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="$USER_HOME$/Installations/miniconda3/envs/clarity-ext/bin/python" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/clarity-ext-scripts/src/clarity-ext/clarity_ext/cli.py" />
+    <option name="PARAMETERS" value="--level INFO extension --cache False clarity_ext_scripts.covid.rename_plates test" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates.py
@@ -1,0 +1,43 @@
+from clarity_ext.extensions import GeneralExtension
+from clarity_ext.domain.validation import UsageError
+
+
+class Extension(GeneralExtension):
+    def execute(self):
+        for container in self.context.output_containers:
+            # self.context.update(container)
+            # Remove the prefix from the container id:
+            template = self.rename_template()
+            container.name = template.format(
+                running_number=self.running_number(container),
+                step=self.step_abbreviation(),
+                date_string=self.date_string())
+
+    @staticmethod
+    def rename_template():
+        """The template used for renaming containers. Override this in inheriting classes"""
+        return "COVID_{running_number}_{step}_{date_string}"
+
+    def step_abbreviation(self):
+        step_name = self.context.current_process_type.name
+        # TODO: Real step names
+        # TODO: Naming of the initial plate (probably an initial step)
+        if step_name == 'Test-Covid19 RNA extraction':
+            return 'RNA'
+        else:
+            UsageError('Step was not recognized: {}'.format(step_name))
+
+    def running_number(self, container):
+        _, running_number = container.id.split("-")
+        return running_number
+
+    def date_string(self):
+        try:
+            if len(self.context.current_step.udf_date_yymmdd) != 6:
+                raise UsageError("The date format is not correct, YYMMDD, leave empty if not used.")
+            return self.time(self.context.current_step.udf_date_yymmdd)
+        except AttributeError:
+            return self.time("%y%m%d")
+
+    def integration_tests(self):
+        yield "24-38714"


### PR DESCRIPTION
Upon creation, plates are automatically named with a running number (lims-id) in Clarity. This script rename plates according to the convention

COVID\_\<running number\>\_\<step abbreviation\>\_\<date\>

Step abbreviations are thought to be
* RNA
* START

In Uppsala, this script is triggered upon entering the details view (no button). This approach will probably be the case here as well. For now, there is no step for the initial sample transfer though.

Note:
I added xml configuration to run the step in pycharm. (as we do in Uppsala clarity framework)
