### PR TITLE
Add script for print barcodes

### DIFF
--- a/.idea/runConfigurations/generate_barcode_list.xml
+++ b/.idea/runConfigurations/generate_barcode_list.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="generate_barcode_list" type="PythonConfigurationType" factoryName="Python" folderName="covid">
+    <module name="claritylims" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="$USER_HOME$/Installations/miniconda3/envs/clarity-ext/bin/python" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/clarity-ext-scripts/src/clarity-ext/clarity_ext/cli.py" />
+    <option name="PARAMETERS" value="--level INFO extension --cache False clarity_ext_scripts.covid.generate_barcode_list test" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
@@ -1,0 +1,15 @@
+from clarity_ext.extensions import GeneralExtension
+from clarity_ext.service.file_service import Csv
+
+
+class Extension(GeneralExtension):
+    def execute(self):
+        csv = Csv(delim='\t', newline='\n')
+        csv.file_name = 'container_names.txt'
+        for container in self.context.output_containers:
+            csv.append([container.name])
+        upload_packet = [(csv.file_name, csv.to_string(include_header=False))]
+        self.context.file_service.upload_files("Print files", upload_packet)
+
+    def integration_tests(self):
+        yield "24-38707"


### PR DESCRIPTION
Purpose:
Make possible to print out plate barcode. I have been informed that the barcode printer is not connected to the network, and I was asked to generate a file with the plate names to be printed out. (The user has to use an USB and go with it to the printer) . 