### PR TITLE
Cov 48 rename plates3

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/plate_name_generator.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/plate_name_generator.py
@@ -3,15 +3,19 @@ from clarity_ext.domain.validation import UsageError
 
 class InheritancePlateNameGenerator:
     """
-    A plate name generator that fetch the running number from the input container
+    A plate name generator that 'inherits' the running number from the input container
     and handles versioning of plates
     """
-    def running_number(self, container, context):
-        first_artifact = container.occupied[0].artifact
+    def running_number(self, output_container, context):
+        """
+        Assuming that there is a 1 to 1 match in the plate layout between source and
+        target plate, fetch running number from the matching input plate
+        """
+        first_artifact = output_container.occupied[0].artifact
         for input, output in context.artifact_service.all_aliquot_pairs():
-            if output.name == first_artifact.name and output.container.name == container.name:
+            if output.name == first_artifact.name and output.container.name == output_container.name:
                 return self._get_running_number_for(input.container.name)
-        raise UsageError('No input plate could be matched against this plate: {}'.format(container.name))
+        raise UsageError('No input plate could be matched against this plate: {}'.format(output_container.name))
 
     def _get_running_number_for(self, container_name):
         split_name = container_name.split('_')

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/plate_name_generator.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/plate_name_generator.py
@@ -33,7 +33,7 @@ class InheritancePlateNameGenerator:
         for i in range(1, max_number_versions):
             trial_name = '{}.v{}'.format(name_base, i)
             response = context.session.api.get_containers(name=trial_name)
-            if response is None:
+            if len(response) == 0:
                 return i
-        return UsageError('Max number of versions exceeded ({}). Please contact system adminstrator.'
+        raise UsageError('Max number of versions exceeded ({}). Please contact system adminstrator.'
                           .format(max_number_versions))

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/rename_plates_rna.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/rename_plates_rna.py
@@ -17,4 +17,4 @@ class Extension(RenamePlatesBase):
         return self.name_generator.running_number(container, self.context)
 
     def integration_tests(self):
-        yield "24-38714"
+        yield "24-38734"


### PR DESCRIPTION
This is a bugfix for renaming plates. The response from lims.get_containers() is an empty list when there were no hits. 