### PR TITLE
COV-85, A stand in script for the qPCR input sample list

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
@@ -12,4 +12,4 @@ class Extension(GeneralExtension):
         self.context.file_service.upload_files("Print files", upload_packet)
 
     def integration_tests(self):
-        yield "24-38707"
+        yield "24-38734"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/qpcr_sample_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/qpcr_sample_list.py
@@ -1,0 +1,24 @@
+from clarity_ext.extensions import GeneralExtension
+from clarity_ext.service.file_service import Csv
+from clarity_ext.domain.validation import UsageError
+
+
+class Extension(GeneralExtension):
+    def execute(self):
+        upload_packets = list()
+        max_number_of_lists = 5  # TODO: decide max number, perhaps it is just 1 anyway?
+        if len(self.context.output_containers) > max_number_of_lists:
+            raise UsageError('The allowed max number of plates is currently set to {},'
+                             ' please contact system administrator'.format(max_number_of_lists))
+        for container in self.context.output_containers:
+            csv = Csv(delim='\t', newline='\n')
+            csv.file_name = 'sample_list_{}.txt'.format(container.name)
+            for well in container.occupied:
+                artifact = well.artifact
+                csv.append([artifact.name, well.index_down_first])
+            upload_packet = (csv.file_name, csv.to_string(include_header=False))
+            upload_packets.append(upload_packet)
+        self.context.file_service.upload_files("Sample list", upload_packets)
+
+    def integration_tests(self):
+        yield "24-38734"


### PR DESCRIPTION
Since the correct format is not known as of yet, we'll start with a script generating the format used in Uppsala facility (as I believe it is). 

The format looks like this:

sample1<tab>well index down first
sample2...

A single sample list is just for one plate. This file has a name telling which plate it is. There is a max limit of how many plates can be handled, which also must be matched against the Clarity configuration of the max number of files under the "Sample list" file handle.
