### PR TITLE
Cov 98, generate a zpl barcode printer file

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list.py
@@ -1,14 +1,15 @@
 from clarity_ext.extensions import GeneralExtension
 from clarity_ext.service.file_service import Csv
+from clarity_ext_scripts.covid.label_printer import label_printer
 
 
 class Extension(GeneralExtension):
     def execute(self):
-        csv = Csv(delim='\t', newline='\n')
-        csv.file_name = 'container_names.txt'
-        for container in self.context.output_containers:
-            csv.append([container.name])
-        upload_packet = [(csv.file_name, csv.to_string(include_header=False))]
+        file_name = 'printfile.zpl'
+        containers = self.context.output_containers
+        label_printer.generate_zpl_for_containers(containers)
+        contents = label_printer.contents
+        upload_packet = [(file_name, contents)]
         self.context.file_service.upload_files("Print files", upload_packet)
 
     def integration_tests(self):

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
@@ -1,0 +1,160 @@
+from lims_snpseq.utils.ftp import FtpChannel
+import re
+
+
+class LabelPrinterService:
+    """Defines the business rules for printing to a label printer"""
+
+    HEIGHT_SHORT = 80
+    HEIGHT_MEDIUM = 120
+    HEIGHT_TALL = 160
+
+    WIDTH_NARROW = 4
+    WIDTH_WIDE = 6
+
+    def __init__(self, printer):
+        self.printer = printer
+
+    def print_bar_code_for_containers(self, containers):
+        """
+        Print out labels for all listed containers, using container name as barcode.
+        Inserts newline in name string according to SNP&SEQ barcode policy (newline
+        before plate id)
+        :param containers: An unique list of containers
+        :return:
+        """
+        newline_pattern = re.compile("(^.+_)(PL\d+_\d+$)")
+        for c in containers:
+            without_prefix = c.id.split("-", 1)[1]
+            processed_name = ""
+            match_res = newline_pattern.match(c.name)
+            if match_res:
+                processed_name = match_res.group(1) + "\n" + match_res.group(2)
+            else:
+                processed_name = c.name
+            self.print_bar_code_for_container(name=processed_name, barcode=without_prefix)
+
+    def print_bar_code_for_container(self, name, barcode):
+        """Prints a default bar code label for a container"""
+        print_info = LabelPrintInfo(name, barcode, self.HEIGHT_TALL,
+                                    self.WIDTH_NARROW, (90, 20), LabelPrintInfo.POS_RIGHT)
+        self.print_label(print_info)
+
+    def print_label(self, label_print_info):
+        """Prints to the registered printer, using a LabelPrintInfo"""
+        self.printer.print_label(label_print_info)
+
+    @staticmethod
+    def create():
+        return LabelPrinterService(LabelPrinterService.create_printer())
+
+    @staticmethod
+    def create_printer():
+        # Creates the default production version of a printer:
+        channel = FtpChannel("molmed-37.medsci.uu.se", ".zpl")
+        return ZebraLabelPrinter(channel, font="B", zoom_factor=4, spacing=5,
+                                 block_width_points=850, label_width_points=1240, text_max_lines=4,
+                                 space_points=20, chars_per_line=28)
+
+
+class LabelPrintInfo:
+    POS_RIGHT = 1
+    POS_TOP = 2
+
+    """Represents what to print, not related to any particular printer"""
+    def __init__(self, text, barcode, height, width, offset, position):
+        """
+        :param text: The label's text
+        :param barcode: The barcode
+        :param height: Height of the label
+        :param width: Module width of barcode (narrow line width used as a base unit for barcode sizing)
+        :param offset: Offset as an (x, y) tuple
+        :param position: Either POS_RIGHT, for aligning the text to the right of the barcode or POS_TOP.
+        """
+        self.text = text
+        self.barcode = barcode
+        self.height = height
+        self.width = width
+        self.offset = offset
+        self.position = position
+
+
+class ZebraLabelPrinter:
+
+    FONT_SIZES = {"A": (5, 9), "B": (7, 11), "C": (10, 18), "D": (10, 18),
+                  "E": (15, 28), "F": (13, 26), "G": (40, 60), "H": (13, 21)}
+
+    """Specifies both the file format needed for this printer as well as the communication mechanism"""
+    def __init__(self, channel, font, zoom_factor, spacing, block_width_points, label_width_points,
+                 text_max_lines, space_points, chars_per_line):
+        # Channel needs to provide a "put" method. Mocking out the channel ensures no side effects
+        self.channel = channel
+        self.font = font
+        self.zoom_factor = zoom_factor
+        self.spacing = spacing
+        self.block_width_points = block_width_points
+        self.label_width_points = label_width_points    #the length of the label in points for easy calc of positions
+
+        self.text_max_lines = text_max_lines
+        self.space_points = space_points
+        self.chars_per_line = chars_per_line
+
+    def print_label(self, info):
+        file_content = self.parse(info)
+        self.channel.put(file_content)
+
+    def _parse(self, info):
+        start            = 11 * info.width
+        data             = len(info.barcode) * 11 * info.width
+        CRC              = 11 * info.width
+        stop             = 12 * info.width
+        text_spacing     = 10 * info.width #spacing between barcode and info text
+
+
+        text_width, text_height = self.FONT_SIZES[self.font]
+        text_width, text_height = text_width * self.zoom_factor, text_height * self.zoom_factor
+
+        yield "^XA"
+        yield "^LH{},{}".format(*info.offset)
+
+        if info.position == LabelPrintInfo.POS_TOP:
+            yield "^A{font}{height},{width}".format(font=self.font, height=text_height, width=text_width)
+            yield "^FO{},{}".format(0, 0)
+            yield "^FD{}^FS".format(info.text)
+
+        yield "^FO{},{}".format(0, text_height + self.spacing)
+
+        yield "^BY{}".format(info.width)
+        yield "^BCN,{},N,N,N".format(info.height)
+        yield "^FD{}^FS".format(info.barcode)
+
+        if info.position == LabelPrintInfo.POS_RIGHT:
+            if info.width <= 4:
+                barcode_width = start + data + CRC + stop + text_spacing
+            else:
+                barcode_width = len(info.barcode) * info.width * 7 + 200
+            yield "^FO{},{}".format(barcode_width, text_height + self.spacing)
+            yield "^A{}{},{}".format(self.font, text_height, text_width)
+            yield "^FB{},{},{},".format(self.label_width_points - info.offset[0] - barcode_width, self.text_max_lines, self.space_points)
+            yield "^FD{}^FS".format(self.replace_newlines(info.text)) #use built in linebreak functionality for bulk of string
+        yield "^XZ"
+
+    def replace_newlines(self, text):
+        return text.replace("\n", "\&")
+
+    def split_text(self, text, new_line, characters_per_line):
+        # NOTE: This could be replaced with textwrap.wrap, but not doing that right away since this
+        # is a direct port from Chiasma (textwrap.wrap removes trailing spaces).
+        def chunks(seq, n):
+            while seq:
+                yield seq[:n]
+                seq = seq[n:]
+        return new_line.join(chunks(text, characters_per_line))
+
+    def parse(self, info):
+        # TODO: Test printing several labels too
+        return "".join(self._parse(info))
+
+
+# Provide a default label_printer so it can be easily used in extensions:
+label_printer = LabelPrinterService.create()

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
@@ -14,7 +14,7 @@ class LabelPrinterService:
     def __init__(self, printer):
         self.printer = printer
 
-    def print_bar_code_for_containers(self, containers):
+    def generate_zpl_for_containers(self, containers):
         """
         Print out labels for all listed containers, using container name as barcode.
         Inserts newline in name string according to SNP&SEQ barcode policy (newline
@@ -31,9 +31,9 @@ class LabelPrinterService:
                 processed_name = match_res.group(1) + "\n" + match_res.group(2)
             else:
                 processed_name = c.name
-            self.print_bar_code_for_container(name=processed_name, barcode=without_prefix)
+            self.generate_zpl_for_container(name=processed_name, barcode=without_prefix)
 
-    def print_bar_code_for_container(self, name, barcode):
+    def generate_zpl_for_container(self, name, barcode):
         """Prints a default bar code label for a container"""
         print_info = LabelPrintInfo(name, barcode, self.HEIGHT_TALL,
                                     self.WIDTH_NARROW, (90, 20), LabelPrintInfo.POS_RIGHT)
@@ -44,7 +44,7 @@ class LabelPrinterService:
         self.printer.append_contents(label_print_info)
 
     @property
-    def printfile_contents(self):
+    def contents(self):
         return '\n'.join(self.printer.contents)
 
     @staticmethod

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
@@ -1,7 +1,7 @@
 import re
 
 
-class LabelPrinterService:
+class LabelPrinterService(object):
     """Defines the business rules for printing to a label printer"""
 
     HEIGHT_SHORT = 80
@@ -59,7 +59,7 @@ class LabelPrinterService:
                                  space_points=20, chars_per_line=28)
 
 
-class LabelPrintInfo:
+class LabelPrintInfo(object):
     POS_RIGHT = 1
     POS_TOP = 2
 
@@ -81,7 +81,7 @@ class LabelPrintInfo:
         self.position = position
 
 
-class ZebraLabelPrinter:
+class ZebraLabelPrinter(object):
 
     FONT_SIZES = {"A": (5, 9), "B": (7, 11), "C": (10, 18), "D": (10, 18),
                   "E": (15, 28), "F": (13, 26), "G": (40, 60), "H": (13, 21)}

--- a/clarity-ext-scripts/tests/test_label_printer.py
+++ b/clarity-ext-scripts/tests/test_label_printer.py
@@ -1,0 +1,28 @@
+import pytest
+from clarity_ext_scripts.covid.label_printer import label_printer
+
+
+class TestLabelPrinter(object):
+    def test_single_container(self):
+        label_printer.printer.contents = list()
+        container = FakeContainer('container1', '92-123')
+        label_printer.generate_zpl_for_containers([container])
+        contents = label_printer.contents
+        assert contents == "^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD123^FS^FO308," \
+                           "49^AB44,28^FB842,4,20,^FDcontainer1^FS^XZ"
+
+    def test_two_containers(self):
+        label_printer.printer.contents = list()
+        container1 = FakeContainer('container1', '92-123')
+        container2 = FakeContainer('container2', '92-124')
+        label_printer.generate_zpl_for_containers([container1, container2])
+        contents = label_printer.contents
+        assert contents == "^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD123^FS^FO308,49^AB44,28^FB842,4,20,"\
+                           "^FDcontainer1^FS^XZ\n^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD124^FS^FO308,"\
+                           "49^AB44,28^FB842,4,20,^FDcontainer2^FS^XZ"
+
+
+class FakeContainer(object):
+    def __init__(self, name, lims_id):
+        self.name = name
+        self.id = lims_id


### PR DESCRIPTION
This script generates a zpl file to be downloaded from Clarity, to be used for printing out plate labels.

Points for extra concern:
* In uppsala there is a separate call to the printer for each container to be printed out. Here, zpl code for all containers in the step is generated into a single file, with each plate separated by a newline. This needs to be verified.
* The actual label barcode (not the text), is here the lims-id of the plate (as in Uppsala). I think that the desired barcode value might be the name of the plate instead. I let the barcode remain the lims-id because I want it to be verified one round before I change further. 