### PR TITLE
Cov 98, generate barcode labels with container names in the barcode

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_long.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_long.py
@@ -5,12 +5,12 @@ from clarity_ext_scripts.covid.label_printer import label_printer
 class Extension(GeneralExtension):
     """
     Generate a list of barcodes as zpl code for containers in step.
-    The barcode is here the lims-id of the containers
+    The barcode is here the name of the containers
     """
     def execute(self):
         file_name = 'printfile.zpl'
         containers = self.context.output_containers
-        label_printer.generate_zpl_for_containers(containers, lims_id_as_barcode=True)
+        label_printer.generate_zpl_for_containers(containers, lims_id_as_barcode=False)
         contents = label_printer.contents
         upload_packet = [(file_name, contents)]
         self.context.file_service.upload_files("Print files", upload_packet)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/label_printer.py
@@ -14,7 +14,7 @@ class LabelPrinterService(object):
     def __init__(self, printer):
         self.printer = printer
 
-    def generate_zpl_for_containers(self, containers):
+    def generate_zpl_for_containers(self, containers, lims_id_as_barcode=False):
         """
         Print out labels for all listed containers, using container name as barcode.
         Inserts newline in name string according to SNP&SEQ barcode policy (newline
@@ -22,16 +22,13 @@ class LabelPrinterService(object):
         :param containers: An unique list of containers
         :return:
         """
-        newline_pattern = re.compile("(^.+_)(PL\d+_\d+$)")
         for c in containers:
-            without_prefix = c.id.split("-", 1)[1]
-            processed_name = ""
-            match_res = newline_pattern.match(c.name)
-            if match_res:
-                processed_name = match_res.group(1) + "\n" + match_res.group(2)
+            if lims_id_as_barcode:
+                # Remove the prefix part of lims id
+                barcode = c.id.split("-", 1)[1]
             else:
-                processed_name = c.name
-            self.generate_zpl_for_container(name=processed_name, barcode=without_prefix)
+                barcode = c.name
+            self.generate_zpl_for_container(name=c.name, barcode=barcode)
 
     def generate_zpl_for_container(self, name, barcode):
         """Prints a default bar code label for a container"""

--- a/clarity-ext-scripts/tests/test_label_printer.py
+++ b/clarity-ext-scripts/tests/test_label_printer.py
@@ -3,23 +3,31 @@ from clarity_ext_scripts.covid.label_printer import label_printer
 
 
 class TestLabelPrinter(object):
-    def test_single_container(self):
+    def test_single_container__with_lims_id_as_barcode(self):
         label_printer.printer.contents = list()
         container = FakeContainer('container1', '92-123')
-        label_printer.generate_zpl_for_containers([container])
+        label_printer.generate_zpl_for_containers([container], lims_id_as_barcode=True)
         contents = label_printer.contents
         assert contents == "^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD123^FS^FO308," \
                            "49^AB44,28^FB842,4,20,^FDcontainer1^FS^XZ"
 
-    def test_two_containers(self):
+    def test_two_containers__with_lims_id_as_barcode(self):
         label_printer.printer.contents = list()
         container1 = FakeContainer('container1', '92-123')
         container2 = FakeContainer('container2', '92-124')
-        label_printer.generate_zpl_for_containers([container1, container2])
+        label_printer.generate_zpl_for_containers([container1, container2], lims_id_as_barcode=True)
         contents = label_printer.contents
         assert contents == "^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD123^FS^FO308,49^AB44,28^FB842,4,20,"\
                            "^FDcontainer1^FS^XZ\n^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FD124^FS^FO308,"\
                            "49^AB44,28^FB842,4,20,^FDcontainer2^FS^XZ"
+
+    def test_single_container__with_name_as_barcode(self):
+        label_printer.printer.contents = list()
+        container = FakeContainer('container1', '92-123')
+        label_printer.generate_zpl_for_containers([container], lims_id_as_barcode=False)
+        contents = label_printer.contents
+        assert contents == "^XA^LH90,20^FO0,49^BY4^BCN,160,N,N,N^FDcontainer1^FS^FO616," \
+                           "49^AB44,28^FB534,4,20,^FDcontainer1^FS^XZ"
 
 
 class FakeContainer(object):


### PR DESCRIPTION
Here, I have created a separate script to generate barcode labels with container name as the actual barcode ( not just the text). There is now two scripts for this (lims-id or container name as barcode), so that both variants can be tested at the same time. When it's decided which to use, we delete the other one. 