### PR TITLE
Cov 140 test partner v7 api client

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -1,4 +1,5 @@
 
+import base64
 from datetime import datetime
 from luhn import verify as mod10verify
 from luhn import generate as mod10generate
@@ -224,9 +225,14 @@ class PartnerAPIV7Client(object):
         try:
             params = {"identifier": "|".join([org, org_referral_code])}
             search_url = "{}/ServiceRequest/".format(self._base_url)
+            user_and_password = "{}:{}".format(self._user, self._password)
+            b64_encoded_user_and_password = base64.b64encode(user_and_password)
+
+            headers = {"Authorization": "Basic {}".format(
+                b64_encoded_user_and_password)}
 
             response = requests.get(url=search_url, params=params,
-                                    auth=(self._user, self._password))
+                                    headers=headers)
 
             # TODO Add integration test mode
 

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -37,9 +37,9 @@ class PartnerAPISampleInformation(object):
 
             if not verify_test_partner_referral_code(referral_code):
                 raise AssertionError(("Check code digit {} (last digit) did not match mod10 requirement"
-                                     "in referral code: {}."
+                                      "in referral code: {}."
                                       "Please verify the code is correct.").format(referral_code[-1],
-                                                                                 referral_code))
+                                                                                   referral_code))
 
             self.referral_code = referral_code
 
@@ -113,11 +113,12 @@ class PartnerAPIClient(object):
             self._integration_test_has_failed += 1
             raise FailedInContactingTestPartner(("'Fake failed' to contact test partner because integration test "
                                                  "mode is active. This is failure {} of {}.").format(
-                                                    self._integration_test_has_failed,
-                                                    self._integration_test_should_fail
-                                                ))
+                self._integration_test_has_failed,
+                self._integration_test_should_fail
+            ))
 
-    @retry((ConnectionError, Timeout), tries=3, delay=2, backoff=2)
+    # TODO Remember to re-enable.
+    # @retry((ConnectionError, Timeout), tries=3, delay=2, backoff=2)
     def send_single_sample_result(self, test_partner_sample_info):
         """
         Send a single sample result to the test partner.
@@ -126,6 +127,9 @@ class PartnerAPIClient(object):
         failure in the exception message. On a successful upload it will return True. Please note that since this
         actually never returns False, it is mostly useful for testing purposes.
         """
+
+        log.debug("Attempting to send information for sample with id: {}".format(
+            test_partner_sample_info.referral_code))
 
         if not isinstance(test_partner_sample_info, PartnerAPISampleInformation):
             raise AssertionError(
@@ -154,6 +158,8 @@ class PartnerAPIClient(object):
             log.error(mess)
             raise FailedInContactingTestPartner(mess)
 
+        log.debug("Got response: {} with text: {}, and headers: {}".format(
+            response, response.text, response.headers))
         # Example of successful API call response
         # success
         # referrral_code=1234567890
@@ -170,8 +176,6 @@ class PartnerAPIClient(object):
             raise FailedInContactingTestPartner(mess)
 
         return True
-
-        # TODO Figure out how text response should be parsed if there is an error.
 
     # TODO Finish this when/if there is a batch API at the partner.
     @retry((ConnectionError, Timeout), tries=3, delay=2, backoff=2)

--- a/clarity-ext-scripts/tests/test_partner_client.py
+++ b/clarity-ext-scripts/tests/test_partner_client.py
@@ -20,6 +20,7 @@ arrival_date=20140310
 test_date=20140310
 result_date=20140310
 comment=ett testmeddelande"""
+            self.headers = {"fake": "value"}
 
     def test_validate_sample_information_instance(self):
         # If all values are ok, don't raise


### PR DESCRIPTION
Here is a first sketch of the search method for the new partner API. Right now it returns the entire ServiceRequest object. I don't know what you think of this? In a way I think it is reasonable that the client is dumb in this regard, on the other hand one could argue that it would be preferable to only return the values that we think we will actually use.