### PR TITLE
covid 122 Analysis service v1

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -6,8 +6,15 @@ import logging
 from clarity_ext_scripts.covid.partner_api_client import VALID_COVID_RESPONSES, \
     COVID_RESPONSE_FAILED, COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
 
-
 log = logging.getLogger(__name__)
+
+FAILED_BY_INTERNAL_CONTROL = "failed_by_internal_control"
+FAILED_BY_TO_HIGH_COVID_VALUE = "failed_by_to_high_covid_value"
+FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL = "failed_entire_plate_by_failed_external_control"
+
+FAILED_STATES = {FAILED_BY_INTERNAL_CONTROL,
+                 FAILED_BY_TO_HIGH_COVID_VALUE,
+                 FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
 
 
 class AnalysisServiceException(Exception):
@@ -26,82 +33,114 @@ class NegativeControlWasPositive(AnalysisServiceException):
     pass
 
 
+class FailedControl(AnalysisServiceException):
+    pass
+
+
 class RTPCRAnalysisService(object):
+    """
+    Create a new RTPCRAnalysis Service:
+        RTPCRAnalysisService(covid_reporter_key="FAM",
+                             internal_control_reporter_key="HEX")
+    """
 
-    HEX_THRESHOLD = 32
-    FAM_THRESHOLD = 38
+    INTERNAL_CONTROL_THRESHOLD = 32
+    COVID_CONTROL_THRESHOLD = 38
 
-    def __init__(self):
-        pass
+    def __init__(self, covid_reporter_key, internal_control_reporter_key):
+        self._covid_reporter_key = covid_reporter_key
+        self._internal_control_reporter = internal_control_reporter_key
 
-# Understanding of the analysis criterias
-# FAM = COVID, HEX = Human internal control
-# Positive if CT(FAM) = <=38
-# Failed  if CT(FAM)= >38
-# Negative if CT(FAM) = 0 and CT(HEX) = <=32
-# Retest if CT(FAM) = 0 and CT(HEX) = >32
+    # These are notes on what Maike said about the analysis
+    # Understanding of the analysis criterias
+    # FAM = COVID, HEX = Human internal control
+    # Positive if CT(FAM) = <=38
+    # Failed  if CT(FAM)= >38
+    # Negative if CT(FAM) = 0 and CT(HEX) = <=32
+    # Retest if CT(FAM) = 0 and CT(HEX) = >32
 
-# TODO Should we issue a re-test status here
-# TODO Later we might have to account for giving two trails over 38 as positive.
+    # TODO Later we might have to account for giving two trails over 38 as positive.
 
     def _analyze_sample(self, sample):
-        fam_ct = sample["FAM-CT"]
-        hex_ct = sample["HEX-CT"]
-        if fam_ct > self.FAM_THRESHOLD:
-            return COVID_RESPONSE_FAILED
-        elif fam_ct == 0 and hex_ct <= self.HEX_THRESHOLD:
+        covid_ct = sample["{}-CT".format(self._covid_reporter_key)]
+        internal_control_ct = sample["{}-CT".format(
+            self._internal_control_reporter)]
+        if covid_ct > self.COVID_CONTROL_THRESHOLD:
+            return FAILED_BY_TO_HIGH_COVID_VALUE
+        elif covid_ct == 0 and internal_control_ct <= self.INTERNAL_CONTROL_THRESHOLD:
             return COVID_RESPONSE_NEGATIVE
-        elif fam_ct == 0 and hex_ct > self.HEX_THRESHOLD:
-            # TODO Should retest and failed be the same thing or not.
-            return COVID_RESPONSE_FAILED
-        elif fam_ct <= self.FAM_THRESHOLD:
+        elif covid_ct == 0 and internal_control_ct > self.INTERNAL_CONTROL_THRESHOLD:
+            return FAILED_BY_INTERNAL_CONTROL
+        elif covid_ct <= self.COVID_CONTROL_THRESHOLD:
             return COVID_RESPONSE_POSITIVE
         else:
-            # TODO Don't know if it is actually a good idea to raise here or not...
-            raise NotImplementedError(
-                "Got CT-value for FAM: {} and CT-value for HEX: {}.".format(fam_ct, hex_ct))
+            raise AssertionError(
+                "Got CT-value for {}: {} and CT-value for {}: {}.".format(self._covid_reporter_key,
+                                                                          covid_ct,
+                                                                          self._internal_control_reporter_key,
+                                                                          internal_control_ct))
 
     def _analyze_controls(self, positive_controls, negative_controls):
         errors = []
-        for pos_control in positive_controls:
-            if self._analyze_sample(pos_control) == COVID_RESPONSE_NEGATIVE:
-                errors += PositiveControlWasNegative(
-                    "Positive control sample: {} was negative for covid-19".format(pos_control["id"]))
+        control_results = []
 
+        for pos_control in positive_controls:
+            res = self._analyze_sample(pos_control)
+            control_results.append({"id": pos_control["id"],
+                                    "diagnosis_result": res})
+
+            if res == COVID_RESPONSE_NEGATIVE:
+                errors.append(PositiveControlWasNegative(
+                    "Positive control sample: {} was negative for covid-19".format(pos_control["id"])))
+            if res in FAILED_STATES:
+                errors.append(FailedControl("Positive control sample: {} failed with status: {}".format(pos_control["id"],
+                                                                                                        res)))
         for neg_control in negative_controls:
-            if self._analyze_sample(neg_control) == COVID_RESPONSE_POSITIVE:
-                errors += NegativeControlWasPositive(
+            res = self._analyze_sample(neg_control)
+            control_results.append({"id": neg_control["id"],
+                                    "diagnosis_result": res})
+
+            if res == COVID_RESPONSE_POSITIVE:
+                errors.append(NegativeControlWasPositive(
                     "Negative control sample: {} was positive for covid-19".format(
-                        neg_control["id"]))
+                        neg_control["id"])))
+            if res in FAILED_STATES:
+                errors.append(FailedControl("Negative control sample: {} failed with status: {}".format(pos_control["id"],
+                                                                                                        res)))
 
         if errors:
             for e in errors:
                 log.error(e.message)
-            raise MultipleAnalysisErrors(errors)
+
+        return control_results, errors
 
     def analyze_samples(self, positive_controls, negative_controls, samples):
         """
         This assumes all controls and samples are from the same plate.
         All samples, and controls should be submitted as dict-like objects on the format:
-         {"id": "<sample id>", "FAM-CT": <value as numeric>, "HEX-Ct": <value as numric>}
+         {"id": "<sample id>", "FAM-CT": <value as numeric>, "HEX-Ct": <value as numeric>}
 
         The method will return a generator of objects on the format:
          {"id": "<same as sample id above>",
-             "diagnosis_result": "<CONST COVID RESPONSE>"}
+             "diagnosis_result": <CONST COVID RESPONSE>}
         """
 
         # TODO Should we validate that there are controls on the plate?
 
         # If controls fail, fail all samples on plate.
-        try:
-            self._analyze_controls(positive_controls, negative_controls)
-        except MultipleAnalysisErrors:
-            for sample in samples:
-                yield {"id": sample["id"], "diagnosis_result": COVID_RESPONSE_FAILED}
-            # No need to continue looking at the samples, as we fail them all here.
-            return
+        control_results, errors = self._analyze_controls(
+            positive_controls, negative_controls)
 
+        for control in control_results:
+            yield control
+
+        # If there were errors in the controls we will fail the entire plate.
+        if errors:
+            for sample in samples:
+                yield {"id": sample["id"],
+                       "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
         # Check samples
-        for sample in samples:
-            result = self._analyze_sample(sample)
-            yield {"id": sample["id"], "diagnosis_result": result}
+        else:
+            for sample in samples:
+                result = self._analyze_sample(sample)
+                yield {"id": sample["id"], "diagnosis_result": result}

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -126,6 +126,13 @@ class RTPCRAnalysisService(object):
         """
 
         # TODO Should we validate that there are controls on the plate?
+        if not positive_controls:
+            raise AssertionError(
+                "Positive controls are missing from input. They are mandatory!")
+
+        if not negative_controls:
+            raise AssertionError(
+                "Negative controls are missing from input. They are mandatory!")
 
         # If controls fail, fail all samples on plate.
         control_results, errors = self._analyze_controls(

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -9,11 +9,11 @@ from clarity_ext_scripts.covid.partner_api_client import VALID_COVID_RESPONSES, 
 log = logging.getLogger(__name__)
 
 FAILED_BY_INTERNAL_CONTROL = "failed_by_internal_control"
-FAILED_BY_TO_HIGH_COVID_VALUE = "failed_by_to_high_covid_value"
+FAILED_BY_TOO_HIGH_COVID_VALUE = "failed_by_too_high_covid_value"
 FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL = "failed_entire_plate_by_failed_external_control"
 
 FAILED_STATES = {FAILED_BY_INTERNAL_CONTROL,
-                 FAILED_BY_TO_HIGH_COVID_VALUE,
+                 FAILED_BY_TOO_HIGH_COVID_VALUE,
                  FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
 
 
@@ -65,7 +65,7 @@ class RTPCRAnalysisService(object):
         covid_ct = sample[self._covid_reporter_key]
         internal_control_ct = sample[self._internal_control_reporter_key]
         if covid_ct > self.COVID_CONTROL_THRESHOLD:
-            return FAILED_BY_TO_HIGH_COVID_VALUE
+            return FAILED_BY_TOO_HIGH_COVID_VALUE
         elif covid_ct == 0 and internal_control_ct <= self.INTERNAL_CONTROL_THRESHOLD:
             return COVID_RESPONSE_NEGATIVE
         elif covid_ct == 0 and internal_control_ct > self.INTERNAL_CONTROL_THRESHOLD:

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -57,7 +57,7 @@ class RTPCRAnalysisService(object):
     # Positive if CT(FAM) = <=38
     # Failed  if CT(FAM)= >38
     # Negative if CT(FAM) = 0 and CT(HEX) = <=32
-    # Retest if CT(FAM) = 0 and CT(HEX) = >32
+    # Failed if CT(FAM) = 0 and CT(HEX) = >32
 
     # TODO Later we might have to account for giving two trails over 38 as positive.
 

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -40,8 +40,8 @@ class FailedControl(AnalysisServiceException):
 class RTPCRAnalysisService(object):
     """
     Create a new RTPCRAnalysis Service:
-        RTPCRAnalysisService(covid_reporter_key="FAM",
-                             internal_control_reporter_key="HEX")
+        RTPCRAnalysisService(covid_reporter_key="FAM-CT",
+                             internal_control_reporter_key="HEX-CT")
     """
 
     INTERNAL_CONTROL_THRESHOLD = 32
@@ -49,7 +49,7 @@ class RTPCRAnalysisService(object):
 
     def __init__(self, covid_reporter_key, internal_control_reporter_key):
         self._covid_reporter_key = covid_reporter_key
-        self._internal_control_reporter = internal_control_reporter_key
+        self._internal_control_reporter_key = internal_control_reporter_key
 
     # These are notes on what Maike said about the analysis
     # Understanding of the analysis criterias
@@ -62,9 +62,8 @@ class RTPCRAnalysisService(object):
     # TODO Later we might have to account for giving two trails over 38 as positive.
 
     def _analyze_sample(self, sample):
-        covid_ct = sample["{}-CT".format(self._covid_reporter_key)]
-        internal_control_ct = sample["{}-CT".format(
-            self._internal_control_reporter)]
+        covid_ct = sample[self._covid_reporter_key]
+        internal_control_ct = sample[self._internal_control_reporter_key]
         if covid_ct > self.COVID_CONTROL_THRESHOLD:
             return FAILED_BY_TO_HIGH_COVID_VALUE
         elif covid_ct == 0 and internal_control_ct <= self.INTERNAL_CONTROL_THRESHOLD:
@@ -151,3 +150,15 @@ class RTPCRAnalysisService(object):
             for sample in samples:
                 result = self._analyze_sample(sample)
                 yield {"id": sample["id"], "diagnosis_result": result}
+
+
+class ABI7500RTPCRAnalysisService(RTPCRAnalysisService):
+    def __init__(self):
+        super(RTPCRAnalysisService, self).__init__(
+            covid_reporter_key="FAM-CT", internal_control_reporter_key="HEX-CT")
+
+
+class QuantStudio7AnalysisService(RTPCRAnalysisService):
+    def __init__(self):
+        super(RTPCRAnalysisService, self).__init__(
+            covid_reporter_key="FAM-CT", internal_control_reporter_key="VIC-CT")

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -169,3 +169,35 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
 
         assert expected == list(result)
+
+    def test_can_analyze_samples_scenario6(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 40, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE},
+            {"id": "cov-1",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-2",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+
+        assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -105,3 +105,37 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL}]
 
         assert expected == list(result)
+
+    def test_can_analyze_samples_scenario4(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3-fail", "FAM-CT": 0, "HEX-CT": 33}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        # TODO Replace sample names so they are less confusing.
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1-pos",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-2-neg",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-3-fail", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+
+        assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -12,6 +12,9 @@ class TestRTPCRAnalysisService(object):
     drive document used to document test cases.
     """
 
+    service = RTPCRAnalysisService(
+        covid_reporter_key="FAM-CT", internal_control_reporter_key="HEX-CT")
+
     def test_can_analyze_samples_scenario1(self):
         """
         Controls are ok. Fail one sample on FAM value
@@ -27,12 +30,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 18}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
@@ -60,12 +60,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 18}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
@@ -95,12 +92,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
@@ -130,12 +124,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
@@ -165,12 +156,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
@@ -200,12 +188,9 @@ class TestRTPCRAnalysisService(object):
                    {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
                    {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
-        service = RTPCRAnalysisService(
-            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
-
-        result = service.analyze_samples(positive_controls=pos_controls,
-                                         negative_controls=neg_controls,
-                                         samples=samples)
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
 
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -137,3 +137,35 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
 
         assert expected == list(result)
+
+    def test_can_analyze_samples_scenario5(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 0, "HEX-CT": 33}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-2",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+
+        assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -7,7 +7,12 @@ import pytest
 
 
 class TestRTPCRAnalysisService(object):
-    def test_can_analyze_samples(self):
+    """
+    Test for the analysis service. The scenarios correspond to the scenarios given in the
+    drive document used to document test cases.
+    """
+
+    def test_can_analyze_samples_scenario1(self):
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
@@ -34,5 +39,69 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-1-pos", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "cov-2-neg", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE}]
+
+        assert expected == list(result)
+
+    def test_can_analyze_samples_scenario2(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 20, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3-fail", "FAM-CT": 40, "HEX-CT": 18}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1-pos",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-2-neg",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-3-fail", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+
+        assert expected == list(result)
+
+    def test_can_analyze_samples_scenario3(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3-fail", "FAM-CT": 0, "HEX-CT": 33}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1-pos",
+                "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-2-neg",
+                "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL}]
 
         assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -20,9 +20,9 @@ class TestRTPCRAnalysisService(object):
         neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
                         {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
 
-        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
-                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
-                   {"id": "cov-3-fail", "FAM-CT": 40, "HEX-CT": 18}]
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 18}]
 
         service = RTPCRAnalysisService(
             covid_reporter_key="FAM", internal_control_reporter_key="HEX")
@@ -36,9 +36,9 @@ class TestRTPCRAnalysisService(object):
             {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-1-pos", "diagnosis_result": COVID_RESPONSE_POSITIVE},
-            {"id": "cov-2-neg", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE}]
+            {"id": "cov-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-3", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE}]
 
         assert expected == list(result)
 
@@ -50,9 +50,9 @@ class TestRTPCRAnalysisService(object):
         neg_controls = [{"id": "neg-1", "FAM-CT": 20, "HEX-CT": 20},
                         {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
 
-        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
-                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
-                   {"id": "cov-3-fail", "FAM-CT": 40, "HEX-CT": 18}]
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 18}]
 
         service = RTPCRAnalysisService(
             covid_reporter_key="FAM", internal_control_reporter_key="HEX")
@@ -66,11 +66,11 @@ class TestRTPCRAnalysisService(object):
             {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-1-pos",
+            {"id": "cov-1",
                 "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
-            {"id": "cov-2-neg",
+            {"id": "cov-2",
                 "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
-            {"id": "cov-3-fail", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+            {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
 
         assert expected == list(result)
 
@@ -82,9 +82,9 @@ class TestRTPCRAnalysisService(object):
         neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
                         {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
 
-        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
-                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
-                   {"id": "cov-3-fail", "FAM-CT": 0, "HEX-CT": 33}]
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
         service = RTPCRAnalysisService(
             covid_reporter_key="FAM", internal_control_reporter_key="HEX")
@@ -98,11 +98,11 @@ class TestRTPCRAnalysisService(object):
             {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-1-pos",
+            {"id": "cov-1",
                 "diagnosis_result": COVID_RESPONSE_POSITIVE},
-            {"id": "cov-2-neg",
+            {"id": "cov-2",
                 "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL}]
+            {"id": "cov-3", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL}]
 
         assert expected == list(result)
 
@@ -114,9 +114,9 @@ class TestRTPCRAnalysisService(object):
         neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
                         {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
 
-        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
-                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
-                   {"id": "cov-3-fail", "FAM-CT": 0, "HEX-CT": 33}]
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 0, "HEX-CT": 33}]
 
         service = RTPCRAnalysisService(
             covid_reporter_key="FAM", internal_control_reporter_key="HEX")
@@ -125,17 +125,15 @@ class TestRTPCRAnalysisService(object):
                                          negative_controls=neg_controls,
                                          samples=samples)
 
-        # TODO Replace sample names so they are less confusing.
-
         expected = [
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-1-pos",
+            {"id": "cov-1",
                 "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
-            {"id": "cov-2-neg",
+            {"id": "cov-2",
                 "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
-            {"id": "cov-3-fail", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+            {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
 
         assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -13,6 +13,9 @@ class TestRTPCRAnalysisService(object):
     """
 
     def test_can_analyze_samples_scenario1(self):
+        """
+        Controls are ok. Fail one sample on FAM value
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
@@ -43,6 +46,9 @@ class TestRTPCRAnalysisService(object):
         assert expected == list(result)
 
     def test_can_analyze_samples_scenario2(self):
+        """
+        Fail on neg control is positive
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
@@ -75,6 +81,9 @@ class TestRTPCRAnalysisService(object):
         assert expected == list(result)
 
     def test_can_analyze_samples_scenario3(self):
+        """
+        Controls are ok. Fail one sample on high HEX value
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
@@ -107,6 +116,9 @@ class TestRTPCRAnalysisService(object):
         assert expected == list(result)
 
     def test_can_analyze_samples_scenario4(self):
+        """
+        Samples fail because positive control has negative result
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 0, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 0, "HEX-CT": 18}]
@@ -139,6 +151,9 @@ class TestRTPCRAnalysisService(object):
         assert expected == list(result)
 
     def test_can_analyze_samples_scenario5(self):
+        """
+        Samples are failed because positive control is failed.
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 0, "HEX-CT": 33}]
@@ -171,6 +186,9 @@ class TestRTPCRAnalysisService(object):
         assert expected == list(result)
 
     def test_can_analyze_samples_scenario6(self):
+        """
+        Samples are failed because negative control failed.
+        """
 
         pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
                         {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -1,0 +1,38 @@
+
+from clarity_ext_scripts.covid.rtpcr_analysis_service import *
+from clarity_ext_scripts.covid.partner_api_client import COVID_RESPONSE_FAILED, \
+    COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
+from mock import patch
+import pytest
+
+
+class TestRTPCRAnalysisService(object):
+    def test_can_analyze_samples(self):
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 20},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 18}]
+
+        samples = [{"id": "cov-1-pos", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2-neg", "FAM-CT": 0, "HEX-CT": 18},
+                   {"id": "cov-3-fail", "FAM-CT": 40, "HEX-CT": 18}]
+
+        service = RTPCRAnalysisService(
+            covid_reporter_key="FAM", internal_control_reporter_key="HEX")
+
+        result = service.analyze_samples(positive_controls=pos_controls,
+                                         negative_controls=neg_controls,
+                                         samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1-pos", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-2-neg", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-3-fail", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE}]
+
+        assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -41,7 +41,7 @@ class TestRTPCRAnalysisService(object):
             {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
             {"id": "cov-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "cov-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "cov-3", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE}]
+            {"id": "cov-3", "diagnosis_result": FAILED_BY_TOO_HIGH_COVID_VALUE}]
 
         assert expected == list(result)
 
@@ -196,7 +196,7 @@ class TestRTPCRAnalysisService(object):
             {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
             {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
-            {"id": "neg-2", "diagnosis_result": FAILED_BY_TO_HIGH_COVID_VALUE},
+            {"id": "neg-2", "diagnosis_result": FAILED_BY_TOO_HIGH_COVID_VALUE},
             {"id": "cov-1",
                 "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
             {"id": "cov-2",


### PR DESCRIPTION
I'm obviously getting a bit senil this late in the week, hence the branch name clims...

Anyway, this is a more final version of the analysis service. It will:
 - return results for all samples, including controls. The script using it needs to check the values if it wants to log or raise exceptions.
 - raise an error if controls are missing.
 - it has multiple failure failed states. These needs to be mapped over to the test partner `failed` status when the results are submitted.
 - it now allows the covid/control results to be stored under dynamic keys. This is set when instantiating the service, and might depend on the qPCR machine used.

I have also added tests corresponding to the test scenarios described in the drive document outlining different scenarios.