### PR TITLE
Handle controls at renaming

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/rename_plates_base.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rename_plates/rename_plates_base.py
@@ -31,6 +31,9 @@ class Extension(GeneralExtension):
         template = self.rename_template()
         for in_cont, out_cont in self.context.containers:
             m = pattern.match(in_cont.name)
+            # Ignore control tubes
+            if m is None:
+                continue
             tokens = m.groupdict()
             tokens["step"] = self.step_abbreviation()
             base_name = template.format(**tokens)


### PR DESCRIPTION
The renaming cast exception when adding controls tubes in step. This PR fixes that. 