### PR TITLE
Cov 144 Adjust rtPCR analysis script to the new service

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_script.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_script.py
@@ -1,60 +1,65 @@
 from clarity_ext.extensions import GeneralExtension
-from clarity_ext_scripts.covid.rtpcr_analysis_service import RTPCRAnalysisService
+from clarity_ext_scripts.covid.rtpcr_analysis_service import ABI7500RTPCRAnalysisService
+from clarity_ext_scripts.covid.rtpcr_analysis_service import MultipleAnalysisErrors
+from clarity_ext_scripts.covid.rtpcr_analysis_service import DIAGNOSIS_RESULT
+from clarity_ext_scripts.covid.rtpcr_analysis_service import COVID_RESPONSE_FAILED
+from clarity_ext_scripts.covid.rtpcr_analysis_service import CTResult
 from clarity_ext.domain.validation import UsageError
 
-BOUNDARY_DICT = {'Assay 1': (10, 50)}
-RT_PCR_POSITIVE_CONTROL = 'rtpcr_pos'
-RT_PCR_NEGATIVE_CONTROL = 'rtpcr_neg'
+
+RT_PCR_POSITIVE_CONTROL = 'Positive PCR Control'
+RT_PCR_NEGATIVE_CONTROL = 'Negative PCR Control'
 
 
 class Extension(GeneralExtension):
     def execute(self):
-        self.initial_validation()
-        ct_analysis_service = RTPCRAnalysisService()
-        lower_bound, upper_bound = BOUNDARY_DICT[self.assay]
-
-        rt_pcr_control_types = [RT_PCR_POSITIVE_CONTROL, RT_PCR_NEGATIVE_CONTROL]
-        found_controls = list()
-        self.context.current_step.udf_map.force("rtPCR Passed", False)
-        for _, output in self.context.all_analytes:
-            original_sample = output.sample()
-            original_sample.udf_map.force("rtPCR Passed", False)
-
-        # 1. Check control values
-        for _, output in self.context.all_analytes:
-            original_sample = output.sample()
-            if original_sample.udf_control == 'Yes' \
-                    and original_sample.udf_control_type.lower() in rt_pcr_control_types:
-                found_controls.append(original_sample.udf_control_type.lower())
-                ct_analysis_service.validate_control_value(
-                    original_sample.udf_control_type, output.udf_ct,
-                    lower_bound, upper_bound)
-
-        if not set(rt_pcr_control_types).issubset(set(found_controls)):
-            raise UsageError('positive and negative rtPCR controls were not found on this plate: {}'
-                             .format(set(found_controls)))
-
-        if not ct_analysis_service.is_valid():
-            return
-
-        # 2. Control values ok, pass this run
-        self.context.current_step.udf_rtpcr_passed = True
-
-        # 3. Populate values
-        for _, output in self.context.all_analytes:
-            original_sample = output.sample()
-            ct = output.udf_ct
-            covid_result = ct_analysis_service.analyze(ct, lower_bound, upper_bound)
-            original_sample.udf_map.force("rtPCR covid-19 result", covid_result)
-            original_sample.udf_map.force("rtPCR Passed", True)
-            self.context.update(original_sample)
-
-    def initial_validation(self):
         if not self._has_assay_udf():
             raise UsageError("The udf 'Assay' must be filled in before running this script")
-        if self.assay not in BOUNDARY_DICT:
-            raise UsageError("The current assay value is not recognized: {}"
-                             .format(self.assay))
+
+        # Prepare analyse service input args
+        ct_analysis_service = ABI7500RTPCRAnalysisService()
+        samples = list()
+        positive_controls = list()
+        negative_controls = list()
+        for _, output in self.context.all_analytes:
+            # TODO: currently we only have udf for CT (no distinction between FAM and HEX)
+            result = CTResult(id=output.id, fam_ct=output.udf_famct, human_gene_ct=output.udf_hexct)
+            result.init_service(ct_analysis_service)
+            if output.name == RT_PCR_POSITIVE_CONTROL:
+                positive_controls.append(result.get_dict())
+            elif output.name == RT_PCR_NEGATIVE_CONTROL:
+                negative_controls.append(result.get_dict())
+            else:
+                samples.append(result.get_dict())
+
+        if len(positive_controls) == 0 or len(negative_controls) == 0:
+            raise UsageError('positive and negative rtPCR controls were not found on this plate.')
+
+        # Check control values
+        self.context.current_step.udf_map.force("rtPCR Passed", True)
+        self.context.update(self.context.current_step)
+        try:
+            ct_analysis_service._analyze_controls(positive_controls, negative_controls)
+        except MultipleAnalysisErrors:
+            self.context.current_step.udf_map.force("rtPCR Passed", False)
+
+        # Fetch results from service
+        result_gen = ct_analysis_service.analyze_samples(
+            positive_controls, negative_controls, samples)
+
+        # Populate udfs
+        artifact_dict = {output.id: output for _, output in self.context.all_analytes}
+        for result in result_gen:
+            output = artifact_dict[result["id"]]
+            original_sample = output.sample()
+            covid_result = result[DIAGNOSIS_RESULT]
+            output.udf_map.force("rtPCR covid-19 result", covid_result)
+            output.udf_map.force("rtPCR Passed", covid_result != COVID_RESPONSE_FAILED)
+            original_sample.udf_map.force("rtPCR covid-19 result latest", covid_result)
+            # TODO: "rtPCR Passed" may be redundant?
+            original_sample.udf_map.force("rtPCR Passed latest", covid_result != COVID_RESPONSE_FAILED)
+            self.context.update(original_sample)
+            self.context.update(output)
 
     @property
     def assay(self):
@@ -69,5 +74,4 @@ class Extension(GeneralExtension):
         return True
 
     def integration_tests(self):
-        # yield "24-39269"
-        yield "24-40616"
+        yield "24-43207"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_test_setup.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_test_setup.py
@@ -1,5 +1,6 @@
 from clarity_ext.extensions import GeneralExtension
-
+from clarity_ext_scripts.covid.rtpcr_analyse_script import RT_PCR_POSITIVE_CONTROL
+from clarity_ext_scripts.covid.rtpcr_analyse_script import RT_PCR_NEGATIVE_CONTROL
 
 class Extension(GeneralExtension):
     """
@@ -12,10 +13,10 @@ class Extension(GeneralExtension):
             original_sample = output.sample()
             if i == 0:
                 original_sample.udf_map.force("Control", "Yes")
-                original_sample.udf_map.force("Control type", "rtpcr_pos")
+                original_sample.udf_map.force("Control type", RT_PCR_POSITIVE_CONTROL)
             elif i == 1:
                 original_sample.udf_map.force("Control", "Yes")
-                original_sample.udf_map.force("Control type", "rtpcr_neg")
+                original_sample.udf_map.force("Control type", RT_PCR_NEGATIVE_CONTROL)
             else:
                 original_sample.udf_map.force("Control", "No")
                 original_sample.udf_map.force("Control type", "")
@@ -26,4 +27,4 @@ class Extension(GeneralExtension):
             i += 1
 
     def integration_tests(self):
-        yield "24-40616"
+        yield "24-43207"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -6,7 +6,7 @@ import logging
 from clarity_ext_scripts.covid.partner_api_client import \
     COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
 
-DIAGNOSIS_RESULT = "diagnosis_result"
+DIAGNOSIS_RESULT_KEY = "diagnosis_result"
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ class RTPCRAnalysisService(object):
 
     def __init__(self, covid_reporter_key, internal_control_reporter_key):
         self._covid_reporter_key = covid_reporter_key
-        self._internal_control_reporter_key = internal_control_reporter_key
+        self.internal_control_reporter_key = internal_control_reporter_key
 
     # These are notes on what Maike said about the analysis
     # Understanding of the analysis criterias
@@ -65,7 +65,7 @@ class RTPCRAnalysisService(object):
 
     def _analyze_sample(self, sample):
         covid_ct = sample[self._covid_reporter_key]
-        internal_control_ct = sample[self._internal_control_reporter_key]
+        internal_control_ct = sample[self.internal_control_reporter_key]
         if covid_ct > self.COVID_CONTROL_THRESHOLD:
             return FAILED_BY_TOO_HIGH_COVID_VALUE
         elif covid_ct == 0 and internal_control_ct <= self.INTERNAL_CONTROL_THRESHOLD:
@@ -78,7 +78,7 @@ class RTPCRAnalysisService(object):
             raise AssertionError(
                 "Got CT-value for {}: {} and CT-value for {}: {}.".format(self._covid_reporter_key,
                                                                           covid_ct,
-                                                                          self._internal_control_reporter_key,
+                                                                          self.internal_control_reporter_key,
                                                                           internal_control_ct))
 
     def _analyze_controls(self, positive_controls, negative_controls):
@@ -87,7 +87,7 @@ class RTPCRAnalysisService(object):
         for pos_control in positive_controls:
             res = self._analyze_sample(pos_control)
             control_results.append({"id": pos_control["id"],
-                                    DIAGNOSIS_RESULT: res})
+                                    DIAGNOSIS_RESULT_KEY: res})
 
             if res == COVID_RESPONSE_NEGATIVE:
                 errors.append(PositiveControlWasNegative(
@@ -98,7 +98,7 @@ class RTPCRAnalysisService(object):
         for neg_control in negative_controls:
             res = self._analyze_sample(neg_control)
             control_results.append({"id": neg_control["id"],
-                                    DIAGNOSIS_RESULT: res})
+                                    DIAGNOSIS_RESULT_KEY: res})
 
             if res == COVID_RESPONSE_POSITIVE:
                 errors.append(NegativeControlWasPositive(
@@ -145,12 +145,12 @@ class RTPCRAnalysisService(object):
         if errors:
             for sample in samples:
                 yield {"id": sample["id"],
-                       DIAGNOSIS_RESULT: FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
+                       DIAGNOSIS_RESULT_KEY: FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
         # Check samples
         else:
             for sample in samples:
                 result = self._analyze_sample(sample)
-                yield {"id": sample["id"], DIAGNOSIS_RESULT: result}
+                yield {"id": sample["id"], DIAGNOSIS_RESULT_KEY: result}
 
 
 class ABI7500RTPCRAnalysisService(RTPCRAnalysisService):

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -1,11 +1,10 @@
 
 import logging
-from collections import namedtuple
 
 
 # TODO Move these constants into some other file
-from clarity_ext_scripts.covid.partner_api_client import VALID_COVID_RESPONSES, \
-    COVID_RESPONSE_FAILED, COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
+from clarity_ext_scripts.covid.partner_api_client import \
+    COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
 
 DIAGNOSIS_RESULT = "diagnosis_result"
 
@@ -164,20 +163,3 @@ class QuantStudio7AnalysisService(RTPCRAnalysisService):
     def __init__(self):
         super(QuantStudio7AnalysisService, self).__init__(
             covid_reporter_key="FAM-CT", internal_control_reporter_key="VIC-CT")
-
-
-class CTResult(namedtuple('CTResult', ['id', 'fam_ct', 'human_gene_ct'])):
-    """
-    Encapsulate contract for input format for this service
-    """
-    def init_service(self, rt_pcr_analysis_service):
-        self.rt_pcr_analysis_service = rt_pcr_analysis_service
-
-    def get_dict(self):
-        internal_control_reporter_key = self.rt_pcr_analysis_service._internal_control_reporter_key
-        dict_template = {
-            "id": self.id,
-            "FAM-CT": self.fam_ct,
-            internal_control_reporter_key: self.human_gene_ct
-        }
-        return dict_template

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -88,7 +88,7 @@ class RTPCRAnalysisService(object):
         for pos_control in positive_controls:
             res = self._analyze_sample(pos_control)
             control_results.append({"id": pos_control["id"],
-                                    "diagnosis_result": res})
+                                    DIAGNOSIS_RESULT: res})
 
             if res == COVID_RESPONSE_NEGATIVE:
                 errors.append(PositiveControlWasNegative(
@@ -99,7 +99,7 @@ class RTPCRAnalysisService(object):
         for neg_control in negative_controls:
             res = self._analyze_sample(neg_control)
             control_results.append({"id": neg_control["id"],
-                                    "diagnosis_result": res})
+                                    DIAGNOSIS_RESULT: res})
 
             if res == COVID_RESPONSE_POSITIVE:
                 errors.append(NegativeControlWasPositive(
@@ -146,12 +146,12 @@ class RTPCRAnalysisService(object):
         if errors:
             for sample in samples:
                 yield {"id": sample["id"],
-                       "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
+                       DIAGNOSIS_RESULT: FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}
         # Check samples
         else:
             for sample in samples:
                 result = self._analyze_sample(sample)
-                yield {"id": sample["id"], "diagnosis_result": result}
+                yield {"id": sample["id"], DIAGNOSIS_RESULT: result}
 
 
 class ABI7500RTPCRAnalysisService(RTPCRAnalysisService):

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -1,10 +1,13 @@
 
 import logging
+from collections import namedtuple
 
 
 # TODO Move these constants into some other file
 from clarity_ext_scripts.covid.partner_api_client import VALID_COVID_RESPONSES, \
     COVID_RESPONSE_FAILED, COVID_RESPONSE_NEGATIVE, COVID_RESPONSE_POSITIVE
+
+DIAGNOSIS_RESULT = "diagnosis_result"
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +85,6 @@ class RTPCRAnalysisService(object):
     def _analyze_controls(self, positive_controls, negative_controls):
         errors = []
         control_results = []
-
         for pos_control in positive_controls:
             res = self._analyze_sample(pos_control)
             control_results.append({"id": pos_control["id"],
@@ -162,3 +164,20 @@ class QuantStudio7AnalysisService(RTPCRAnalysisService):
     def __init__(self):
         super(RTPCRAnalysisService, self).__init__(
             covid_reporter_key="FAM-CT", internal_control_reporter_key="VIC-CT")
+
+
+class CTResult(namedtuple('CTResult', ['id', 'fam_ct', 'human_gene_ct'])):
+    """
+    Encapsulate contract for input format for this service
+    """
+    def init_service(self, rt_pcr_analysis_service):
+        self.rt_pcr_analysis_service = rt_pcr_analysis_service
+
+    def get_dict(self):
+        internal_control_reporter_key = self.rt_pcr_analysis_service._internal_control_reporter_key
+        dict_template = {
+            "id": self.id,
+            "FAM-CT": self.fam_ct,
+            internal_control_reporter_key: self.human_gene_ct
+        }
+        return dict_template

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -156,13 +156,13 @@ class RTPCRAnalysisService(object):
 
 class ABI7500RTPCRAnalysisService(RTPCRAnalysisService):
     def __init__(self):
-        super(RTPCRAnalysisService, self).__init__(
+        super(ABI7500RTPCRAnalysisService, self).__init__(
             covid_reporter_key="FAM-CT", internal_control_reporter_key="HEX-CT")
 
 
 class QuantStudio7AnalysisService(RTPCRAnalysisService):
     def __init__(self):
-        super(RTPCRAnalysisService, self).__init__(
+        super(QuantStudio7AnalysisService, self).__init__(
             covid_reporter_key="FAM-CT", internal_control_reporter_key="VIC-CT")
 
 


### PR DESCRIPTION
Points for extra concern:
* There are currently no udf for gene-specific CT values, there is only one CT value, so we have to decide on that. 
* In code, I refer to udf "FAM-CT", but that must change when we decide the setup of udfs. 
* Contract for input format (CTResult) is now added to the analysis service
* Step udf "rtPCR Passed" is set based on control failure/passed (not samples)
* Controls are once again recognized by its name (not udfs)
* errors += Exception, does not work, they'll transform to strings, so I changed it. 
* I think that results for controls should be stored in the lims. But currently, control results are not accessible from the service. 