### PR TITLE
cov-130, separate code for parsing and analyse scripts

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr.py
@@ -1,46 +1,11 @@
-# -*- coding: utf-8 -*-
-
-import pandas as pd
 from clarity_ext.extensions import GeneralExtension
-from datetime import datetime
-
-CT_HEADER = u"Cт"
+from clarity_ext_scripts.covid.parse_pcr_execution import ParsePcrExecution
 
 
 class Extension(GeneralExtension):
     def execute(self):
-        file_name = "Result file"
-        f = self.context.local_shared_file(file_name, mode="rb")
-        data = pd.read_excel(f, 'Results', index_col=0, skiprows=7, encoding='utf-8')
-        rt_pcr_analyze_service = RTPCRAnalyseService(self.context)
-
-        for _, output in self.context.all_analytes:
-            entry = data.loc[output.well.alpha_num_key]
-            target_name = entry["Target Name"]
-
-            if target_name != output.name:
-                raise AssertionError("Incorrect name of target '{}' in well '{}' in '{}'. "
-                        "Expected {}".format(
-                            target_name, output.well.alpha_num_key, file_name, output.name))
-
-            ct = entry[CT_HEADER]
-
-            # add the measurement to the output artifact
-            output.udf_map.force("CT", ct)
-            self.context.update(output)
-
-            # also add the measurement to the original sample, where it should be understood
-            # as the latest measurement
-
-            # ISO format without the microseconds
-            now_iso = datetime.now().isoformat().split(".")[0]
-
-            original_sample = output.sample()
-            original_sample.udf_map.force("CT latest", ct)
-            original_sample.udf_map.force("CT latest date", now_iso)
-            # LIMS ID of the source of the CT measurement
-            original_sample.udf_map.force("CT source", output.api_resource.uri)
-            self.context.update(original_sample)
+        runner = ParsePcrExecution(self.context)
+        runner.execute()
 
     def integration_tests(self):
         yield "24-39151"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+from datetime import datetime
+
+CT_HEADER = u"Cт"
+
+
+class ParsePcrExecution(object):
+    def __init__(self, context):
+        self.context = context
+
+    def execute(self):
+        file_name = "Result file"
+        f = self.context.local_shared_file(file_name, mode="rb")
+        data = pd.read_excel(f, 'Results', index_col=0, skiprows=7, encoding='utf-8')
+        rt_pcr_analyze_service = RTPCRAnalyseService(self.context)
+
+        for _, output in self.context.all_analytes:
+            entry = data.loc[output.well.alpha_num_key]
+            target_name = entry["Target Name"]
+
+            if target_name != output.name:
+                raise AssertionError("Incorrect name of target '{}' in well '{}' in '{}'. "
+                        "Expected {}".format(
+                            target_name, output.well.alpha_num_key, file_name, output.name))
+
+            ct = entry[CT_HEADER]
+
+            # add the measurement to the output artifact
+            output.udf_map.force("CT", ct)
+            self.context.update(output)
+
+            # also add the measurement to the original sample, where it should be understood
+            # as the latest measurement
+
+            # ISO format without the microseconds
+            now_iso = datetime.now().isoformat().split(".")[0]
+
+            original_sample = output.sample()
+            original_sample.udf_map.force("CT latest", ct)
+            original_sample.udf_map.force("CT latest date", now_iso)
+            # LIMS ID of the source of the CT measurement
+            original_sample.udf_map.force("CT source", output.api_resource.uri)
+            self.context.update(original_sample)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
@@ -1,0 +1,106 @@
+from clarity_ext_scripts.covid.rtpcr_analysis_service import ABI7500RTPCRAnalysisService
+from clarity_ext_scripts.covid.rtpcr_analysis_service import DIAGNOSIS_RESULT_KEY
+from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL
+from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_STATES
+from clarity_ext.domain.validation import UsageError
+
+
+RT_PCR_POSITIVE_CONTROL = 'Positive PCR Control'
+RT_PCR_NEGATIVE_CONTROL = 'Negative PCR Control'
+
+
+class RtPcrAnalyseExecution(object):
+    def __init__(self, context):
+        self.context = context
+
+    def execute(self):
+        if not self._has_assay_udf():
+            raise UsageError("The udf 'Assay' must be filled in before running this script")
+
+        if not self._has_instrument_udf():
+            raise UsageError("The udf 'Instrument Used' must be filled in before running this script")
+
+        # Prepare analyse service input args
+        ct_analysis_service, udf_name_for_ct_control = self._instantiate_service()
+        samples = list()
+        positive_controls = list()
+        negative_controls = list()
+        for _, output in self.context.all_analytes:
+            result = {
+                "id": output.id,
+                "FAM-CT": output.udf_famct,
+                udf_name_for_ct_control: output.udf_map[udf_name_for_ct_control].value,
+            }
+            if output.name == RT_PCR_POSITIVE_CONTROL:
+                positive_controls.append(result)
+            elif output.name == RT_PCR_NEGATIVE_CONTROL:
+                negative_controls.append(result)
+            else:
+                samples.append(result)
+
+        if len(positive_controls) == 0 or len(negative_controls) == 0:
+            raise UsageError('positive and negative rtPCR controls were not found on this plate.')
+
+        # Fetch results from service
+        result_gen = ct_analysis_service.analyze_samples(
+            positive_controls, negative_controls, samples)
+
+        # Populate udfs
+        artifact_dict = {output.id: output for _, output in self.context.all_analytes}
+        for result in result_gen:
+            output = artifact_dict[result["id"]]
+            original_sample = output.sample()
+            covid_result = result[DIAGNOSIS_RESULT_KEY]
+            output.udf_map.force("rtPCR covid-19 result", covid_result)
+            output.udf_map.force("rtPCR Passed", covid_result not in FAILED_STATES)
+            original_sample.udf_map.force("rtPCR covid-19 result latest", covid_result)
+            # TODO: "rtPCR Passed" may be redundant?
+            original_sample.udf_map.force("rtPCR Passed latest", covid_result not in FAILED_STATES)
+            self.context.update(original_sample)
+            self.context.update(output)
+
+        # Check control values
+        artifacts_that_failed = [
+            name for name in artifact_dict
+            if artifact_dict[name].udf_rtpcr_covid19_result ==
+               FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL
+        ]
+        rt_pcr_passed = len(artifacts_that_failed) == 0
+        self.context.current_step.udf_map.force("rtPCR Passed", rt_pcr_passed)
+        self.context.update(self.context.current_step)
+
+    def _instantiate_service(self):
+        if self.instrument == 'qPCR ABI 7500':
+            service = ABI7500RTPCRAnalysisService()
+        elif self.instrument == 'Quant Studio 7':
+            service = QuantStudio7AnalysisService()
+        else:
+            raise UsageError("The instrument in 'Instrument Used' is not recognized: {}"
+                             .format(self.instrument))
+
+        udf_name_for_ct_control = service.internal_control_reporter_key
+        return service, udf_name_for_ct_control
+
+    @property
+    def assay(self):
+        return self.context.current_step.udf_assay
+
+    @property
+    def instrument(self):
+        return self.context.current_step.udf_instrument_used
+
+    def _has_instrument_udf(self):
+        try:
+            _ = self.instrument
+        except AttributeError:
+            return False
+
+        return True
+
+    def _has_assay_udf(self):
+        try:
+            _ = self.assay
+        except AttributeError:
+            return False
+
+        return True

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_script.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_script.py
@@ -1,108 +1,11 @@
 from clarity_ext.extensions import GeneralExtension
-from clarity_ext_scripts.covid.rtpcr_analysis_service import ABI7500RTPCRAnalysisService
-from clarity_ext_scripts.covid.rtpcr_analysis_service import QuantStudio7AnalysisService
-from clarity_ext_scripts.covid.rtpcr_analysis_service import DIAGNOSIS_RESULT_KEY
-from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL
-from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_STATES
-from clarity_ext.domain.validation import UsageError
-
-
-RT_PCR_POSITIVE_CONTROL = 'Positive PCR Control'
-RT_PCR_NEGATIVE_CONTROL = 'Negative PCR Control'
+from clarity_ext_scripts.covid.rtpcr_analyse_execution import RtPcrAnalyseExecution
 
 
 class Extension(GeneralExtension):
     def execute(self):
-        if not self._has_assay_udf():
-            raise UsageError("The udf 'Assay' must be filled in before running this script")
-
-        if not self._has_instrument_udf():
-            raise UsageError("The udf 'Instrument Used' must be filled in before running this script")
-
-        # Prepare analyse service input args
-        ct_analysis_service, udf_name_for_ct_control = self._instantiate_service()
-        samples = list()
-        positive_controls = list()
-        negative_controls = list()
-        for _, output in self.context.all_analytes:
-            result = {
-                "id": output.id,
-                "FAM-CT": output.udf_famct,
-                udf_name_for_ct_control: output.udf_map[udf_name_for_ct_control].value,
-            }
-            if output.name == RT_PCR_POSITIVE_CONTROL:
-                positive_controls.append(result)
-            elif output.name == RT_PCR_NEGATIVE_CONTROL:
-                negative_controls.append(result)
-            else:
-                samples.append(result)
-
-        if len(positive_controls) == 0 or len(negative_controls) == 0:
-            raise UsageError('positive and negative rtPCR controls were not found on this plate.')
-
-        # Fetch results from service
-        result_gen = ct_analysis_service.analyze_samples(
-            positive_controls, negative_controls, samples)
-
-        # Populate udfs
-        artifact_dict = {output.id: output for _, output in self.context.all_analytes}
-        for result in result_gen:
-            output = artifact_dict[result["id"]]
-            original_sample = output.sample()
-            covid_result = result[DIAGNOSIS_RESULT_KEY]
-            output.udf_map.force("rtPCR covid-19 result", covid_result)
-            output.udf_map.force("rtPCR Passed", covid_result not in FAILED_STATES)
-            original_sample.udf_map.force("rtPCR covid-19 result latest", covid_result)
-            # TODO: "rtPCR Passed" may be redundant?
-            original_sample.udf_map.force("rtPCR Passed latest", covid_result not in FAILED_STATES)
-            self.context.update(original_sample)
-            self.context.update(output)
-
-        # Check control values
-        artifacts_that_failed = [
-            name for name in artifact_dict
-            if artifact_dict[name].udf_rtpcr_covid19_result ==
-               FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL
-        ]
-        rt_pcr_passed = len(artifacts_that_failed) == 0
-        self.context.current_step.udf_map.force("rtPCR Passed", rt_pcr_passed)
-        self.context.update(self.context.current_step)
-
-    def _instantiate_service(self):
-        if self.instrument == 'qPCR ABI 7500':
-            service = ABI7500RTPCRAnalysisService()
-        elif self.instrument == 'Quant Studio 7':
-            service = QuantStudio7AnalysisService()
-        else:
-            raise UsageError("The instrument in 'Instrument Used' is not recognized: {}"
-                             .format(self.instrument))
-
-        udf_name_for_ct_control = service.internal_control_reporter_key
-        return service, udf_name_for_ct_control
-
-    @property
-    def assay(self):
-        return self.context.current_step.udf_assay
-
-    @property
-    def instrument(self):
-        return self.context.current_step.udf_instrument_used
-
-    def _has_instrument_udf(self):
-        try:
-            _ = self.instrument
-        except AttributeError:
-            return False
-
-        return True
-
-    def _has_assay_udf(self):
-        try:
-            _ = self.assay
-        except AttributeError:
-            return False
-
-        return True
+        runner = RtPcrAnalyseExecution(self.context)
+        runner.execute()
 
     def integration_tests(self):
         yield "24-43207"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_parse_and_analyze.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_parse_and_analyze.py
@@ -1,0 +1,14 @@
+from clarity_ext.extensions import GeneralExtension
+from clarity_ext_scripts.covid.parse_pcr_execution import ParsePcrExecution
+from clarity_ext_scripts.covid.rtpcr_analyse_execution import RtPcrAnalyseExecution
+
+
+class Extension(GeneralExtension):
+    def execute(self):
+        parse_runner = ParsePcrExecution(self.context)
+        parse_runner.execute()
+        analyze_runner = RtPcrAnalyseExecution(self.context)
+        analyze_runner.execute()
+
+    def integration_tests(self):
+        yield "24-39151"


### PR DESCRIPTION
My initial intention with this was to make possible to trigger either parse + analyse, or only analyze. Now, I realize that this is not required. Still, I see a point in being able to separate code for different tasks, parsing and analyze. 