### PR TITLE
Cov 130 parse quant7

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -4,7 +4,7 @@ import pandas as pd
 from datetime import datetime
 from clarity_ext.domain.validation import UsageError
 
-CT_HEADER = u"Cт"
+CT_HEADER_OLD = u"Cт"
 
 
 class ParsePcrExecution(object):
@@ -45,22 +45,32 @@ class Quant7Parser(object):
     def __init__(self, context):
         self.context = context
 
-    def parse(self, file_name):
-        file_stream = self.context.local_shared_file(file_name, mode="rb")
-        data = pd.read_excel(file_stream, 'Results', index_col=0, skiprows=7, encoding='utf-8')
-        for _, output in self.context.all_analytes:
-            entry = data.loc[output.well.alpha_num_key]
-            target_name = entry["Target Name"]
+    def _determine_start_row(self, file_handle):
+        file_stream = self.context.local_shared_file(file_handle, mode="rb")
+        data = pd.read_excel(file_stream, 'Results', index_col=None, encoding='utf-8')
+        header_row_entry = data[(data[0] == 'Well') & (data[1] == 'Well Position')].index
+        header_row_index = header_row_entry.values[0]
+        return header_row_index
 
+    def parse(self, file_handle):
+        header_row_index = self._determine_start_row(file_handle)
+        file_stream = self.context.local_shared_file(file_handle, mode="rb")
+        data = pd.read_excel(file_stream, 'Results', index_col=None, skiprows=header_row_index, encoding='utf-8')
+        for _, output in self.context.all_analytes:
+            fam_row = data.loc[(data['Sample Name'] == 'sample1') & (data['Reporter'] == 'FAM')]
+            vic_row = data.loc[(data['Sample Name'] == 'sample1') & (data['Reporter'] == 'VIC')]
+            target_name = fam_row["Sample Name"]
             if target_name != output.name:
                 raise AssertionError("Incorrect name of target '{}' in well '{}' in '{}'. "
                         "Expected {}".format(
-                            target_name, output.well.alpha_num_key, file_name, output.name))
+                            target_name, output.well.alpha_num_key, file_handle, output.name))
 
-            ct = entry[CT_HEADER]
+            fam_ct = fam_row["CT"]
+            vic_ct = vic_row["CT"]
 
             # add the measurement to the output artifact
-            output.udf_map.force("CT", ct)
+            output.udf_map.force("FAM-CT", fam_ct)
+            output.udf_map.force("VIC-CT", vic_ct)
             self.context.update(output)
 
             # also add the measurement to the original sample, where it should be understood
@@ -70,7 +80,8 @@ class Quant7Parser(object):
             now_iso = datetime.now().isoformat().split(".")[0]
 
             original_sample = output.sample()
-            original_sample.udf_map.force("CT latest", ct)
+            original_sample.udf_map.force("FAM-CT latest", fam_ct)
+            original_sample.udf_map.force("VIC-CT latest", vic_ct)
             original_sample.udf_map.force("CT latest date", now_iso)
             # LIMS ID of the source of the CT measurement
             original_sample.udf_map.force("CT source", output.api_resource.uri)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -4,8 +4,6 @@ import pandas as pd
 from datetime import datetime
 from clarity_ext.domain.validation import UsageError
 
-CT_HEADER_OLD = u"Cт"
-
 
 class ParsePcrExecution(object):
     def __init__(self, context):
@@ -57,8 +55,8 @@ class Quant7Parser(object):
         file_stream = self.context.local_shared_file(file_handle, mode="rb")
         data = pd.read_excel(file_stream, 'Results', index_col=None, skiprows=header_row_index, encoding='utf-8')
         for _, output in self.context.all_analytes:
-            fam_row = data.loc[(data['Sample Name'] == 'sample1') & (data['Reporter'] == 'FAM')]
-            vic_row = data.loc[(data['Sample Name'] == 'sample1') & (data['Reporter'] == 'VIC')]
+            fam_row = data.loc[(data['Sample Name'] == output.name) & (data['Reporter'] == 'FAM')]
+            vic_row = data.loc[(data['Sample Name'] == output.name) & (data['Reporter'] == 'VIC')]
             target_name = fam_row["Sample Name"]
             if target_name != output.name:
                 raise AssertionError("Incorrect name of target '{}' in well '{}' in '{}'. "

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 from datetime import datetime
+from clarity_ext.domain.validation import UsageError
 
 CT_HEADER = u"Cт"
 
@@ -11,10 +12,42 @@ class ParsePcrExecution(object):
         self.context = context
 
     def execute(self):
-        file_name = "Result file"
-        f = self.context.local_shared_file(file_name, mode="rb")
-        data = pd.read_excel(f, 'Results', index_col=0, skiprows=7, encoding='utf-8')
+        if not self._has_instrument_udf():
+            raise UsageError("The udf 'Instrument Used' must be filled in before running this script")
+        file_handle = "Result file"
+        parser = self._instantiate_parser()
+        parser.parse(file_handle)
 
+    def _instantiate_parser(self):
+        if self.instrument == 'qPCR ABI 7500':
+            raise UsageError('Parsing qPCR ABI 7500 is not implemented')
+        elif self.instrument == 'Quant Studio 7':
+            parser = Quant7Parser(self.context)
+        else:
+            raise UsageError("The instrument in 'Instrument Used' is not recognized: {}"
+                             .format(self.instrument))
+        return parser
+
+    @property
+    def instrument(self):
+        return self.context.current_step.udf_instrument_used
+
+    def _has_instrument_udf(self):
+        try:
+            _ = self.instrument
+        except AttributeError:
+            return False
+
+        return True
+
+
+class Quant7Parser(object):
+    def __init__(self, context):
+        self.context = context
+
+    def parse(self, file_name):
+        file_stream = self.context.local_shared_file(file_name, mode="rb")
+        data = pd.read_excel(file_stream, 'Results', index_col=0, skiprows=7, encoding='utf-8')
         for _, output in self.context.all_analytes:
             entry = data.loc[output.well.alpha_num_key]
             target_name = entry["Target Name"]

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -14,7 +14,6 @@ class ParsePcrExecution(object):
         file_name = "Result file"
         f = self.context.local_shared_file(file_name, mode="rb")
         data = pd.read_excel(f, 'Results', index_col=0, skiprows=7, encoding='utf-8')
-        rt_pcr_analyze_service = RTPCRAnalyseService(self.context)
 
         for _, output in self.context.all_analytes:
             entry = data.loc[output.well.alpha_num_key]

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
@@ -1,4 +1,5 @@
 from clarity_ext_scripts.covid.rtpcr_analysis_service import ABI7500RTPCRAnalysisService
+from clarity_ext_scripts.covid.rtpcr_analysis_service import QuantStudio7AnalysisService
 from clarity_ext_scripts.covid.rtpcr_analysis_service import DIAGNOSIS_RESULT_KEY
 from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL
 from clarity_ext_scripts.covid.rtpcr_analysis_service import FAILED_STATES


### PR DESCRIPTION
Adjust the pcr parse script to the quant 7 output file

* There is not other implementation than quant 7.

This is to a very limited extent tested. I think it better to quickly share the latest status of this work. 

Caveat:
* the way to get "instrument" was changed this morning and must be updated. 