### PR TITLE
Fix instrument reference

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -28,7 +28,7 @@ class ParsePcrExecution(object):
 
     @property
     def instrument(self):
-        return self.context.current_step.udf_instrument_used
+        return self.context.current_step.instrument
 
     def _has_instrument_udf(self):
         try:

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analyse_execution.py
@@ -88,7 +88,7 @@ class RtPcrAnalyseExecution(object):
 
     @property
     def instrument(self):
-        return self.context.current_step.udf_instrument_used
+        return self.context.current_step.instrument
 
     def _has_instrument_udf(self):
         try:


### PR DESCRIPTION
According to the Clarity setup used at Sthlm site, the instrument is imported as a field directly under current step. Hence, not in an udf as in Uppsala. This is an adjustment for that. 