### PR TITLE
Fix parse script so that integration test passes

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr.py
@@ -8,4 +8,4 @@ class Extension(GeneralExtension):
         runner.execute()
 
     def integration_tests(self):
-        yield "24-39151"
+        yield "24-43214"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/parse_pcr_execution.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import pandas as pd
+import numpy as np
 from datetime import datetime
 from clarity_ext.domain.validation import UsageError
-
 
 class ParsePcrExecution(object):
     def __init__(self, context):
@@ -45,7 +45,7 @@ class Quant7Parser(object):
 
     def _determine_start_row(self, file_handle):
         file_stream = self.context.local_shared_file(file_handle, mode="rb")
-        data = pd.read_excel(file_stream, 'Results', index_col=None, encoding='utf-8')
+        data = pd.read_excel(file_stream, 'Results', index_col=None, header=None, encoding='utf-8')
         header_row_entry = data[(data[0] == 'Well') & (data[1] == 'Well Position')].index
         header_row_index = header_row_entry.values[0]
         return header_row_index
@@ -53,18 +53,29 @@ class Quant7Parser(object):
     def parse(self, file_handle):
         header_row_index = self._determine_start_row(file_handle)
         file_stream = self.context.local_shared_file(file_handle, mode="rb")
-        data = pd.read_excel(file_stream, 'Results', index_col=None, skiprows=header_row_index, encoding='utf-8')
+        data = pd.read_excel(file_stream, 'Results', index_col=None,
+                             skiprows=header_row_index, encoding='utf-8')
         for _, output in self.context.all_analytes:
+            try:
+                _ = data.loc[(data['Sample Name'] == output.name)]
+            except KeyError:
+                raise UsageError("Sample name could not be found in pcr output file: {}".format(output.name))
             fam_row = data.loc[(data['Sample Name'] == output.name) & (data['Reporter'] == 'FAM')]
             vic_row = data.loc[(data['Sample Name'] == output.name) & (data['Reporter'] == 'VIC')]
-            target_name = fam_row["Sample Name"]
+            target_name = fam_row["Sample Name"].values[0]
             if target_name != output.name:
                 raise AssertionError("Incorrect name of target '{}' in well '{}' in '{}'. "
                         "Expected {}".format(
                             target_name, output.well.alpha_num_key, file_handle, output.name))
 
-            fam_ct = fam_row["CT"]
-            vic_ct = vic_row["CT"]
+            fam_ct = fam_row["CT"].values[0]
+            # CT values with no signal is shown as an empty cell in the output file
+            # which in turn is interpreted as NaN by pandas.
+            if np.isnan(fam_ct):
+                fam_ct = 0
+            vic_ct = vic_row["CT"].values[0]
+            if np.isnan(vic_ct):
+                vic_ct = 0
 
             # add the measurement to the output artifact
             output.udf_map.force("FAM-CT", fam_ct)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/pcr/input_file_rt-pcr.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/pcr/input_file_rt-pcr.py
@@ -31,4 +31,4 @@ class Extension(TemplateExtension):
                 yield artifact
 
     def integration_tests(self):
-        yield self.test("24-39282", commit=False)
+        yield self.test("24-43214", commit=False)


### PR DESCRIPTION
These are the updates I've done when running integration tests with the parse_pcr script

The script execution now passes without crashing (without these changes the script crashes), although I have not yet checked that the udf values are correct. Normally I have a helper script that fetches udf values from a step. But my last run on the integration test took me about 10 minutes, because the connection was broken over and over again, so that's why I didn't check the udf values. 

(The analyse script is not yet tested in an integration test)