### PR TITLE
Sample with no signal should now fail

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -85,7 +85,7 @@ class RTPCRAnalysisService(object):
             return FAILED_BY_INTERNAL_CONTROL
         elif covid_ct > self.COVID_CONTROL_THRESHOLD:
             return FAILED_BY_TOO_HIGH_COVID_VALUE
-        elif covid_ct <= self.COVID_CONTROL_THRESHOLD and not covid_ct == 0:
+        elif covid_ct <= self.COVID_CONTROL_THRESHOLD and covid_ct > 0:
             return COVID_RESPONSE_POSITIVE
         else:
             raise AssertionError(

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/rtpcr_analysis_service.py
@@ -85,7 +85,7 @@ class RTPCRAnalysisService(object):
             return FAILED_BY_INTERNAL_CONTROL
         elif covid_ct > self.COVID_CONTROL_THRESHOLD:
             return FAILED_BY_TOO_HIGH_COVID_VALUE
-        elif covid_ct <= self.COVID_CONTROL_THRESHOLD and covid_ct > 0:
+        elif 0 < covid_ct <= self.COVID_CONTROL_THRESHOLD:
             return COVID_RESPONSE_POSITIVE
         else:
             raise AssertionError(

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -267,3 +267,34 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-3", "diagnosis_result": FAILED_BY_TOO_HIGH_COVID_VALUE}]
 
         assert expected == list(result)
+
+    def test_can_analyze_samples_scenario9(self):
+        """
+        For no signal for pos control. Fail plate.
+        """
+        pos_controls = [{"id": "pos-1", "FAM-CT": 0, "HEX-CT": 0},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 0},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 0}]
+
+        samples = [{"id": "cov-1", "FAM-CT": 0, "HEX-CT": 0},
+                   {"id": "cov-2", "FAM-CT": 14, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 33}]
+
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": FAILED_BY_INTERNAL_CONTROL},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-2",
+                "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL},
+            {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
+
+        assert expected == list(result)

--- a/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
+++ b/clarity-ext-scripts/tests/test_rtpcr_analysis_service.py
@@ -204,3 +204,66 @@ class TestRTPCRAnalysisService(object):
             {"id": "cov-3", "diagnosis_result": FAILED_ENTIRE_PLATE_BY_FAILED_EXTERNAL_CONTROL}]
 
         assert expected == list(result)
+
+    def test_can_analyze_samples_scenario7(self):
+        """
+        For no signal on both channels of a negative control, it should be negative
+        """
+
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 0},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 0}]
+
+        samples = [{"id": "cov-1", "FAM-CT": 20, "HEX-CT": 20},
+                   {"id": "cov-2", "FAM-CT": 14, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 33}]
+
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1",
+                "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-2",
+                "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-3", "diagnosis_result": FAILED_BY_TOO_HIGH_COVID_VALUE}]
+
+        assert expected == list(result)
+
+    def test_can_analyze_samples_scenario8(self):
+        """
+        For no signal on both channels of a sample, it should fail
+        """
+        pos_controls = [{"id": "pos-1", "FAM-CT": 25, "HEX-CT": 20},
+                        {"id": "pos-2", "FAM-CT": 20, "HEX-CT": 18}]
+
+        neg_controls = [{"id": "neg-1", "FAM-CT": 0, "HEX-CT": 0},
+                        {"id": "neg-2", "FAM-CT": 0, "HEX-CT": 0}]
+
+        samples = [{"id": "cov-1", "FAM-CT": 0, "HEX-CT": 0},
+                   {"id": "cov-2", "FAM-CT": 14, "HEX-CT": 18},
+                   {"id": "cov-3", "FAM-CT": 40, "HEX-CT": 33}]
+
+        result = self.service.analyze_samples(positive_controls=pos_controls,
+                                              negative_controls=neg_controls,
+                                              samples=samples)
+
+        expected = [
+            {"id": "pos-1", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "pos-2", "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "neg-1", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "neg-2", "diagnosis_result": COVID_RESPONSE_NEGATIVE},
+            {"id": "cov-1",
+                "diagnosis_result": FAILED_BY_INTERNAL_CONTROL},
+            {"id": "cov-2",
+                "diagnosis_result": COVID_RESPONSE_POSITIVE},
+            {"id": "cov-3", "diagnosis_result": FAILED_BY_TOO_HIGH_COVID_VALUE}]
+
+        assert expected == list(result)


### PR DESCRIPTION
No signal, i.e. HEX=0 and VIC=0 is ok for the negative control sample, but not for any other type of sample. This handles that.