### PR TITLE
Split up script, update original samples at step exit

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/review_update_global.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/review_update_global.py
@@ -1,14 +1,33 @@
 from clarity_ext.extensions import GeneralExtension
+from clarity_ext.domain.validation import UsageError
 
 
 class Extension(GeneralExtension):
     def execute(self):
+        self._validate()
         for _, output in self.context.artifact_service.all_aliquot_pairs():
             original_sample = output.sample
             original_sample.udf_map.force(
                 "rtPCR covid-19 result latest", output.udf_rtpcr_covid19_result)
             original_sample.udf_map.force("rtPCR Passed latest", output.udf_rtpcr_passed)
             self.context.update(original_sample)
+
+    def _validate(self):
+        error_artifacts = list()
+        for _, output in self.context.artifact_service.all_aliquot_pairs():
+            if not self._has_covid19_result(output):
+                error_artifacts.append(output)
+        if len(error_artifacts) > 0:
+            raise UsageError("The update script must be run before exiting!")
+
+    def _has_covid19_result(self, artifact):
+        try:
+            result = artifact.udf_rtpcr_covid19_result
+            if result is None:
+                return False
+        except AttributeError:
+            return False
+        return True
 
     def integration_tests(self):
         yield self.test("24-45334", commit=True)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/review_update_global.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/review_update_global.py
@@ -1,0 +1,14 @@
+from clarity_ext.extensions import GeneralExtension
+
+
+class Extension(GeneralExtension):
+    def execute(self):
+        for _, output in self.context.artifact_service.all_aliquot_pairs():
+            original_sample = output.sample
+            original_sample.udf_map.force(
+                "rtPCR covid-19 result latest", output.udf_rtpcr_covid19_result)
+            original_sample.udf_map.force("rtPCR Passed latest", output.udf_rtpcr_passed)
+            self.context.update(original_sample)
+
+    def integration_tests(self):
+        yield self.test("24-45334", commit=True)


### PR DESCRIPTION
Purpose:
At reviewer step, updates of artifacts and original samples happens in two steps
1) user press button to run script. Logic is applied on filed "Reviewer result" to update covid19 results on artifact level only
2) user exits step. Values of covid19 result on sample level is transferred to sample level. 