### PR TITLE
Populate udf 'Biobank barcode' at sample creation

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
@@ -4,6 +4,7 @@ from clarity_ext.domain.validation import UsageError
 from clarity_ext.utils import single
 
 BIOBANK_FILE_HEADER = ['well', 'biobank_barcode', 'something_else', 'plate_barcode']
+RAW_BIOANK_LIST = "Raw biobank list"
 
 
 class FetchBiobankBarcodes(object):
@@ -23,21 +24,24 @@ class FetchBiobankBarcodes(object):
         """
         self.validate()
         self.barcode_by_sample_code =\
-            self.biobank_barcode_by_sample_referal_code()
+            self.biobank_barcode_by_sample_referral_code()
         self._print(self.barcode_by_sample_code)
 
     def validate(self):
         try:
-            file_stream = self.context.local_shared_file('Raw biobank list')
+            file_stream = self.context.local_shared_file(RAW_BIOANK_LIST)
         except IOError:
-            raise UsageError("Please upload the file to 'Raw barcode list' before proceeding!")
+            raise UsageError("Please upload the file to '{}' before proceeding!"
+                             .format(RAW_BIOANK_LIST))
 
-        biobank_matrix = self._build_biobank_matrix(file_stream)
+        biobank_info_by_well_barcode = self._build_biobank_info_by_well_barcode(file_stream)
         plate_barcodes = {
-            biobank_matrix[key]['plate_barcode'] for key in biobank_matrix
+            biobank_info_by_well_barcode[key]['plate_barcode']
+            for key in biobank_info_by_well_barcode
         }
         if len(plate_barcodes) > 1:
-            raise UsageError("There are more than one destination plates the file in 'Raw barcode list'!")
+            raise UsageError("There are more than one destination plates the file in '{}'!"
+                             .format(RAW_BIOANK_LIST))
 
         # Validate that sample list file has plate barcode as name
         filenames = self.context.file_service.list_filenames('Raw sample list')
@@ -46,44 +50,43 @@ class FetchBiobankBarcodes(object):
         if plate_barcode not in base_names:
             raise UsageError(
                 "The 'Raw sample list' name is not matching with the plate "
-                "barcode in 'Raw biobank list', {}".format(plate_barcode))
+                "barcode in '{}', {}".format(RAW_BIOANK_LIST, plate_barcode))
 
         # Validate that all wells in biobank file are matched in sample list file
         file_stream2 = self.context.local_shared_file('Raw sample list')
-        sample_matrix = self._build_sample_matrix(file_stream2, plate_barcode)
-        for key in biobank_matrix:
-            try:
-                if biobank_matrix[key]['biobank_barcode'] != 'NO TUBE':
-                    _ = sample_matrix[key]['Sample Id']
-            except KeyError:
+        sample_info_by_well_barcode = \
+            self._build_sample_info_by_well_barcode(file_stream2, plate_barcode)
+        for key in biobank_info_by_well_barcode:
+            if biobank_info_by_well_barcode[key]['biobank_barcode'] != 'NO TUBE' \
+                    and key not in sample_info_by_well_barcode:
                 raise UsageError(
                     "The well references are not matching between the "
-                    "files in 'Raw biobank list' and 'Raw sample list, "
+                    "files in '{}' and 'Raw sample list, "
                     "well '{}' has no match in the 'Raw sample list'"
-                    .format(biobank_matrix[key]['well'])
+                    .format(RAW_BIOANK_LIST, biobank_info_by_well_barcode[key]['well'])
                 )
 
         # Validate that 'NO TUBE' entries in biobank file is empty in sample list
         # Perhaps this is a little too aggressive validation?
-        sample_matrix_keys = [k for k in sample_matrix]
-        for key in biobank_matrix:
-            if biobank_matrix[key]['biobank_barcode'] == 'NO TUBE' \
+        sample_matrix_keys = [k for k in sample_info_by_well_barcode]
+        for key in biobank_info_by_well_barcode:
+            if biobank_info_by_well_barcode[key]['biobank_barcode'] == 'NO TUBE' \
                     and key in sample_matrix_keys \
-                    and sample_matrix[key]['Sample Id']:
-                biobank_well = biobank_matrix[key]['well']
-                sample_list_well = sample_matrix[key]['Position']
+                    and sample_info_by_well_barcode[key]['Sample Id']:
+                biobank_well = biobank_info_by_well_barcode[key]['well']
+                sample_list_well = sample_info_by_well_barcode[key]['Position']
                 raise UsageError(
                     "There is an empty entry in the biobank barcode file "
                     "that is not empty in the sample list file, "
                     "biobank well: {}, sample list well: {}"
                     .format(biobank_well, sample_list_well))
 
-    def biobank_barcode_by_sample_referal_code(self):
-        file_stream = self.context.local_shared_file('Raw biobank list')
-        biobank_matrix = self._build_biobank_matrix(file_stream)
+    def biobank_barcode_by_sample_referral_code(self):
+        file_stream = self.context.local_shared_file(RAW_BIOANK_LIST)
+        biobank_matrix = self._build_biobank_info_by_well_barcode(file_stream)
         plate_barcode = self._plate_barcode_from(biobank_matrix)
         file_stream2 = self.context.local_shared_file('Raw sample list')
-        sample_matrix = self._build_sample_matrix(file_stream2, plate_barcode)
+        sample_matrix = self._build_sample_info_by_well_barcode(file_stream2, plate_barcode)
         barcode_map = dict()
         for key in biobank_matrix:
             if biobank_matrix[key]['biobank_barcode'] == 'NO TUBE':
@@ -94,9 +97,9 @@ class FetchBiobankBarcodes(object):
 
         return barcode_map
 
-    def _build_sample_matrix(self, file_stream, plate_barcode):
+    def _build_sample_info_by_well_barcode(self, file_stream, plate_barcode):
         csv = Csv(file_stream)
-        matrix = dict()
+        sample_info_by_well_barcode = dict()
         pattern = re.compile(r"(?P<row>[A-Z])(?P<col>[0-9]+)")
         for line in csv:
             trimmed_row = map(str.strip, line.values)
@@ -107,17 +110,18 @@ class FetchBiobankBarcodes(object):
                 continue
             tokens = m.groupdict()
             well_default_format = '{}{}'.format(tokens['row'], int(tokens['col']))
-            matrix[self._biobank_key(well_default_format, plate_barcode)] = row_as_dict
-        return matrix
+            sample_info_by_well_barcode[
+                self._biobank_key(well_default_format, plate_barcode)] = row_as_dict
+        return sample_info_by_well_barcode
 
     def _print(self, var):
         from pprint import pprint
         pprint(var)
 
-    def _build_biobank_matrix(self, file_stream):
+    def _build_biobank_info_by_well_barcode(self, file_stream):
         contents = file_stream.read()
         rows = contents.split('\n')
-        matrix = dict()
+        biobank_info_by_well_barcode = dict()
         for row in rows:
             split_row = row.split(",")
             if len(split_row) != len(BIOBANK_FILE_HEADER):
@@ -126,8 +130,8 @@ class FetchBiobankBarcodes(object):
             row_as_dict = dict(zip(BIOBANK_FILE_HEADER, trimmed_row))
             well = row_as_dict['well']
             plate_barcode = row_as_dict['plate_barcode']
-            matrix[self._biobank_key(well, plate_barcode)] = row_as_dict
-        return matrix
+            biobank_info_by_well_barcode[self._biobank_key(well, plate_barcode)] = row_as_dict
+        return biobank_info_by_well_barcode
 
     def _plate_barcode_from(self, biobank_matrix):
         any_key = [k for k in biobank_matrix][0]

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
@@ -1,0 +1,137 @@
+import re
+from clarity_ext.service.file_service import Csv
+from clarity_ext.domain.validation import UsageError
+from clarity_ext.utils import single
+
+BIOBANK_FILE_HEADER = ['well', 'biobank_barcode', 'something_else', 'plate_barcode']
+
+
+class FetchBiobankBarcodes(object):
+    """
+    This is intended to be part of create samples script. By injecting context,
+    it might be tested in isolation by creating a dummy script.
+    """
+
+    def __init__(self, context):
+        self.context = context
+        self.barcode_by_sample_code = None
+
+    def execute(self):
+        """
+        Just for testing, validate() and map_barcodes() are called separately from
+        different scripts
+        """
+        self.validate()
+        self.barcode_by_sample_code =\
+            self.biobank_barcode_by_sample_referal_code()
+        self._print(self.barcode_by_sample_code)
+
+    def validate(self):
+        try:
+            file_stream = self.context.local_shared_file('Raw biobank list')
+        except IOError:
+            raise UsageError("Please upload the file to 'Raw barcode list' before proceeding!")
+
+        biobank_matrix = self._build_biobank_matrix(file_stream)
+        plate_barcodes = {
+            biobank_matrix[key]['plate_barcode'] for key in biobank_matrix
+        }
+        if len(plate_barcodes) > 1:
+            raise UsageError("There are more than one destination plates the file in 'Raw barcode list'!")
+
+        # Validate that sample list file has plate barcode as name
+        filenames = self.context.file_service.list_filenames('Raw sample list')
+        base_names = [n.split('.')[0] for n in filenames]
+        plate_barcode = single(list(plate_barcodes))
+        if plate_barcode not in base_names:
+            raise UsageError(
+                "The 'Raw sample list' name is not matching with the plate "
+                "barcode in 'Raw biobank list', {}".format(plate_barcode))
+
+        # Validate that all wells in biobank file are matched in sample list file
+        file_stream2 = self.context.local_shared_file('Raw sample list')
+        sample_matrix = self._build_sample_matrix(file_stream2, plate_barcode)
+        for key in biobank_matrix:
+            try:
+                if biobank_matrix[key]['biobank_barcode'] != 'NO TUBE':
+                    _ = sample_matrix[key]['Sample Id']
+            except KeyError:
+                raise UsageError(
+                    "The well references are not matching between the "
+                    "files in 'Raw biobank list' and 'Raw sample list, "
+                    "well '{}' has no match in the 'Raw sample list'"
+                    .format(biobank_matrix[key]['well'])
+                )
+
+        # Validate that 'NO TUBE' entries in biobank file is empty in sample list
+        # Perhaps this is a little too aggressive validation?
+        sample_matrix_keys = [k for k in sample_matrix]
+        for key in biobank_matrix:
+            if biobank_matrix[key]['biobank_barcode'] == 'NO TUBE' \
+                    and key in sample_matrix_keys \
+                    and sample_matrix[key]['Sample Id']:
+                biobank_well = biobank_matrix[key]['well']
+                sample_list_well = sample_matrix[key]['Position']
+                raise UsageError(
+                    "There is an empty entry in the biobank barcode file "
+                    "that is not empty in the sample list file, "
+                    "biobank well: {}, sample list well: {}"
+                    .format(biobank_well, sample_list_well))
+
+    def biobank_barcode_by_sample_referal_code(self):
+        file_stream = self.context.local_shared_file('Raw biobank list')
+        biobank_matrix = self._build_biobank_matrix(file_stream)
+        plate_barcode = self._plate_barcode_from(biobank_matrix)
+        file_stream2 = self.context.local_shared_file('Raw sample list')
+        sample_matrix = self._build_sample_matrix(file_stream2, plate_barcode)
+        barcode_map = dict()
+        for key in biobank_matrix:
+            if biobank_matrix[key]['biobank_barcode'] == 'NO TUBE':
+                continue
+            biobank_barcode = biobank_matrix[key]['biobank_barcode']
+            sample_referal_code = sample_matrix[key]['Sample Id']
+            barcode_map[sample_referal_code] = biobank_barcode
+
+        return barcode_map
+
+    def _build_sample_matrix(self, file_stream, plate_barcode):
+        csv = Csv(file_stream)
+        matrix = dict()
+        pattern = re.compile(r"(?P<row>[A-Z])(?P<col>[0-9]+)")
+        for line in csv:
+            trimmed_row = map(str.strip, line.values)
+            row_as_dict = dict(zip(csv.header, trimmed_row))
+            well_robot_format = line['Position']
+            m = pattern.match(well_robot_format)
+            if m is None:
+                continue
+            tokens = m.groupdict()
+            well_default_format = '{}{}'.format(tokens['row'], int(tokens['col']))
+            matrix[self._biobank_key(well_default_format, plate_barcode)] = row_as_dict
+        return matrix
+
+    def _print(self, var):
+        from pprint import pprint
+        pprint(var)
+
+    def _build_biobank_matrix(self, file_stream):
+        contents = file_stream.read()
+        rows = contents.split('\n')
+        matrix = dict()
+        for row in rows:
+            split_row = row.split(",")
+            if len(split_row) != len(BIOBANK_FILE_HEADER):
+                continue
+            trimmed_row = map(str.strip, split_row)
+            row_as_dict = dict(zip(BIOBANK_FILE_HEADER, trimmed_row))
+            well = row_as_dict['well']
+            plate_barcode = row_as_dict['plate_barcode']
+            matrix[self._biobank_key(well, plate_barcode)] = row_as_dict
+        return matrix
+
+    def _plate_barcode_from(self, biobank_matrix):
+        any_key = [k for k in biobank_matrix][0]
+        return biobank_matrix[any_key]['plate_barcode']
+
+    def _biobank_key(self, well, plate_barcode):
+        return '{}_{}'.format(well, plate_barcode)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
@@ -188,7 +188,7 @@ class Extension(GeneralExtension):
         from clarity_ext_scripts.covid.fetch_biobank_barcodes import FetchBiobankBarcodes
         fetch_biobank_barcodes = FetchBiobankBarcodes(self.context)
         barcode_by_sample =\
-            fetch_biobank_barcodes.biobank_barcode_by_sample_referal_code()
+            fetch_biobank_barcodes.biobank_barcode_by_sample_referral_code()
         prext_plate = self.create_in_mem_container(csv,
                                                    container_specifier="PREXT",
                                                    sample_specifier="",

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
@@ -108,12 +108,12 @@ class Extension(GeneralExtension):
                 substance = self.create_sample(
                     original_name, timestamp, project, sample_specifier, org_uri,
                     service_request_id)
+                if biobank_barcode_by_sample_referal_code:
+                    biobank_barcode = biobank_barcode_by_sample_referal_code[
+                        original_name
+                    ]
+                    substance.udf_map.force("Biobank barcode", biobank_barcode)
             substance.udf_map.force("Sample Buffer", "None")
-            if biobank_barcode_by_sample_referal_code:
-                biobank_barcode = biobank_barcode_by_sample_referal_code(
-                    original_name
-                )
-                substance.udf_map.force("Biobank barcode", biobank_barcode)
             container[well] = substance
         return container
 
@@ -220,4 +220,4 @@ class Extension(GeneralExtension):
         self.context.update(self.context.current_step)
 
     def integration_tests(self):
-        yield self.test("24-44013", commit=True)
+        yield self.test("24-44042", commit=True)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
@@ -59,7 +59,9 @@ class Extension(GeneralExtension):
         return control
 
     def create_in_mem_container(
-            self, csv, container_specifier, sample_specifier, control_specifier, date, time):
+            self, csv, container_specifier, sample_specifier, control_specifier, date, time,
+            biobank_barcode_by_sample_referal_code=None
+    ):
         """Creates an in-memory container with the samples
 
         The name of the container will be on the form:
@@ -107,6 +109,11 @@ class Extension(GeneralExtension):
                     original_name, timestamp, project, sample_specifier, org_uri,
                     service_request_id)
             substance.udf_map.force("Sample Buffer", "None")
+            if biobank_barcode_by_sample_referal_code:
+                biobank_barcode = biobank_barcode_by_sample_referal_code(
+                    original_name
+                )
+                substance.udf_map.force("Biobank barcode", biobank_barcode)
             container[well] = substance
         return container
 
@@ -178,6 +185,10 @@ class Extension(GeneralExtension):
             self.usage_error(msg)
 
         # 3. Create the two plates in memory
+        from clarity_ext_scripts.covid.fetch_biobank_barcodes import FetchBiobankBarcodes
+        fetch_biobank_barcodes = FetchBiobankBarcodes(self.context)
+        barcode_by_sample =\
+            fetch_biobank_barcodes.biobank_barcode_by_sample_referal_code()
         prext_plate = self.create_in_mem_container(csv,
                                                    container_specifier="PREXT",
                                                    sample_specifier="",
@@ -190,7 +201,8 @@ class Extension(GeneralExtension):
                                                      sample_specifier="BIOBANK",
                                                      control_specifier="BIOBANK",
                                                      date=date,
-                                                     time=time)
+                                                     time=time,
+                                                     biobank_barcode_by_sample_referal_code=barcode_by_sample)
 
         # 4. Create the container and samples in clarity
         workflow = self.context.current_step.udf_assign_to_workflow
@@ -208,4 +220,4 @@ class Extension(GeneralExtension):
         self.context.update(self.context.current_step)
 
     def integration_tests(self):
-        yield "24-44033"
+        yield self.test("24-44013", commit=True)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
@@ -70,6 +70,12 @@ class Extension(GeneralExtension):
         return service_request_id, status, comment
 
     def execute(self):
+        # Validate the 'Raw biobank file' exists and is in concordance with the 'Raw sample list'
+        # if not, abort script execution
+        from clarity_ext_scripts.covid.fetch_biobank_barcodes import FetchBiobankBarcodes
+        validator = FetchBiobankBarcodes(self.context)
+        validator.validate()
+
         # 1. Get the ordering organizations URI
         try:
             ordering_org = self.context.current_step.udf_ordering_organization

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 import logging
 from datetime import datetime
 import pandas as pd
-from clarity_ext_scripts.covid.controls import Controls
 from clarity_ext.extensions import GeneralExtension
 from clarity_ext_scripts.covid.partner_api_client import (
     PartnerAPIV7Client, TESTING_ORG, ORG_URI_BY_NAME, OrganizationReferralCodeNotFound, PartnerClientAPIException)


### PR DESCRIPTION
Purpose:
Fetch biobank barcodes from the 'Raw biobank list' and populate udf 'Biobank barcode' at sample creation. In addition, validate that the plate barcode in the 'Raw biobank list' is matching the name of the 'Raw sample list' file. 

Points for careful concern:
* Validation of the 'Raw biobank list' occurs at top of the 'validate_sample_creation_list'. 
* 'Biobank barcodes' are populated at sample creation at the 'import_samples' script.
* The validation fails if a sample is missing in one of the files (sample list or barcodes), but exist in the other. That's perhaps a little to hard criterion?

Validation:
* I have validated on a Clarity step with files containing 1 sample and a number of controls. (validate sample creation list, import samples). 