### PR TITLE
Fix bug with mismatching files

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/fetch_biobank_barcodes.py
@@ -78,7 +78,7 @@ class FetchBiobankBarcodes(object):
         file_stream2 = self.context.local_shared_file('Raw sample list')
         sample_matrix = self._build_sample_info_by_well_barcode(file_stream2, plate_barcode)
         barcode_map = dict()
-        for key in biobank_matrix:
+        for key in sample_matrix:
             if biobank_matrix[key]['biobank_barcode'] == 'NO TUBE':
                 continue
             biobank_barcode = biobank_matrix[key]['biobank_barcode']


### PR DESCRIPTION
Rectify a bug in create samples, that manifested itself when a plate is not entirely filled up. In that case, the raw biobank file still has all wells registered, while the sample list file have missing wells. This scenario weren't handled by code. 

I thought that I fixed this already, but I just removed the validation for when this happens. When the script do the actual mapping of biobank barcodes -  samples, there was still an exception. 