### PR TITLE
Bug fix for faked statuses

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/create_samples/common.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/create_samples/common.py
@@ -105,6 +105,11 @@ class ValidatedSampleListFile(PandasWrapper):
     STATUS_ERROR = "error"
     STATUS_UNREGISTERED = "unregistered"
 
+    STATUS_ALL = [
+        STATUS_OK,
+        STATUS_ERROR,
+        STATUS_UNREGISTERED
+    ] 
 
 BUTTON_TEXT_ASSIGN_UNREGISTERED_TO_ANONYMOUS = "Assign unregistered to anonymous"
 
@@ -126,7 +131,13 @@ class BaseValidateRawSampleListExtension(GeneralExtension):
         barcode = str(row[validated_sample_list.COLUMN_REFERENCE])
 
         if ordering_org == TESTING_ORG:
+            # The user can send in a "fake status" from the raw sample list, by including it
+            # in COLUMN_FAKE_STATUS. If we don't recognize it as one of the status flags, we
+            # should just use "ok"
             status = row[validated_sample_list.COLUMN_FAKE_STATUS]
+            if status not in validated_sample_list.STATUS_ALL:
+                status = validated_sample_list.STATUS_OK
+
             comment = "This data is faked for integration purposes (Internal testing was selected)"
 
             if status == validated_sample_list.STATUS_OK:

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/create_samples/generate_demo_files.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/create_samples/generate_demo_files.py
@@ -45,16 +45,18 @@ class Extension(GeneralExtension):
                 samples_and_controls.append((generated, abbreviation))
 
             for ix, sample_or_control_info in enumerate(samples_and_controls):
-                sample_or_control_id, sample_or_control_name = sample_or_control_info
+                sample_or_control_id, extra_info = sample_or_control_info
                 rack_id = "LVL" + timestamp
                 row = chr(ix % rows + ord("A"))
                 col = ix / rows + 1
                 cavity_id = "{}_{}{:03d}".format(rack_id, row, col)
                 pos = "{}{:02d}".format(row, col)
+
                 yield ([rack_id, cavity_id, pos, sample_or_control_id] +
-                       [""] * 3 +
-                       [sample_or_control_name] +
-                       [""] * 8)
+                       [""] * 3 +  # "CONCENTRATION", "CONCENTRATIONUNIT", "VOLUME"
+                       [""] * 4 +  # COLUMN_USER_DEFINED1-4 
+                       [extra_info] +  # COLUMN_USER_DEFINED5, info only
+                       [""] * 4)
 
             # Add postfix rows that should be ignored later
             extra_cols = [""] * (len(RawSampleListFile.HEADERS) - 1)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/validate_sample_creation_list.py
@@ -17,16 +17,18 @@ class RawSampleListColumns(object):
     COLUMN_REFERENCE = "Sample Id"
     COLUMN_POSITION = "Position"
     COLUMN_USER_DEFINED1 = "USERDEFINED1"
+    COLUMN_USER_DEFINED5 = "USERDEFINED5"
 
     HEADERS = ["Rack Id", "Cavity Id",
                COLUMN_POSITION, COLUMN_REFERENCE,
                "CONCENTRATION", "CONCENTRATIONUNIT", "VOLUME",
-               COLUMN_USER_DEFINED1,  # Contains a control name or the integration test knm status
-               "USERDEFINED2", "USERDEFINED3", "USERDEFINED4", "USERDEFINED5",
+               COLUMN_USER_DEFINED1,
+               "USERDEFINED2", "USERDEFINED3", "USERDEFINED4",
+               COLUMN_USER_DEFINED5,  # Contains a control name or the integration test knm status
                "PlateErrors", "SampleErrors", "SAMPLEINSTANCEID", "SAMPLEID"]
 
     # The column from which we can get the fake status in integration tests
-    COLUMN_FAKE_STATUS = COLUMN_USER_DEFINED1
+    COLUMN_FAKE_STATUS = COLUMN_USER_DEFINED5
 
 
 class RawSampleListFile(RawSampleListColumns, BaseRawSampleListFile):


### PR DESCRIPTION
Fake statuses, used in integration testing, are now in column
USERDEFINED5 and the status defaults to ok if we don't recognize the
status