### PR TITLE
Create samples scripts looks for 'reference'

### DIFF
--- a/.idea/runConfigurations/covid_create_discarded_samples.xml
+++ b/.idea/runConfigurations/covid_create_discarded_samples.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="covid.create_discarded_samples" type="PythonConfigurationType" factoryName="Python" folderName="covid">
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="PYCHARM_HOSTED" value="1" />
+      <env name="PYTHONIOENCODING" value="UTF-8" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/clarity-ext-scripts/repos/clarity-ext/clarity_ext" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="false" />
+    <option name="ADD_SOURCE_ROOTS" value="false" />
+    <module name="claritylims" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/clarity-ext-scripts/repos/clarity-ext/clarity_ext/cli.py" />
+    <option name="PARAMETERS" value="--level INFO extension --cache True clarity_ext_scripts.covid.create_discard_samples test" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <method />
+  </configuration>
+</component>

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/create_discard_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/create_discard_samples.py
@@ -78,7 +78,7 @@ class Extension(BaseCreateSamplesExtension):
         container = Container(container_type=container_type, name=name)
 
         # 3. Create in-memory sample
-        original_name = row["reference"]
+        original_name = row["Sample Id"]
         org_uri = row["org_uri"]
         service_request_id = row["service_request_id"]
 
@@ -151,4 +151,4 @@ class Extension(BaseCreateSamplesExtension):
             self.context.file_service.FILE_PREFIX_NONE)
 
     def integration_tests(self):
-        yield self.test("24-46737", commit=True)
+        yield self.test("24-47148", commit=False)


### PR DESCRIPTION
- After renaming headers the script was looking for reference and not
Sample Id