### PR TITLE
Replace CodeSystem/cs-test-types code covid19 with SARS-CoV-2-RNA

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -322,7 +322,7 @@ class PartnerAPIV7Client(object):
                     {
                         "system": "{}/id/CodeSystem/cs-test-types".format(
                             self._test_partner_code_system_base_url),
-                        "code": "covid19"
+                        "code": "SARS-CoV-2-RNA"
                     }
                 ]
             }


### PR DESCRIPTION
KNM will change the CodeSystem for `cs-test-types` _very_ soon (it was almost accidentally deployed into KNM production earlier today before they realized we are heavy users of this in our anonymous ServiceRequest creation). 

This change is rather urgent (lots of other users of KNM's system depend on this change). I would like to merge and get this into production by tomorrow morning @withrocks @chichackles. But first, I would like to have it merged into `dev` so we can test it against the KNM test environment that already has this change implemented, preferably tonight, so we are ready for a deployment into `prod` first thing tomorrow morning.

Would it be a lot of work to push this from dev to prod tomorrow morning before we start work at 9:00? @chichackles @withrocks 