### PR TITLE
Cov 248 change test type code for anonymous service requests

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -322,7 +322,7 @@ class PartnerAPIV7Client(object):
                     {
                         "system": "{}/id/CodeSystem/cs-test-types".format(
                             self._test_partner_code_system_base_url),
-                        "code": "covid19"
+                        "code": "SARS-CoV-2-RNA"
                     }
                 ]
             }


### PR DESCRIPTION
Merge KUL integration and change the `covid19` string to `SARS-Cov-2-RNA` into prod. The last one is a bit of a hotfix due to an imminent change in KNM's system.

Please hold the merge until I've confirmed the update in the KNM production system.