### PR TITLE
Potential fix for inability to create anon service requests

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -305,6 +305,9 @@ class PartnerAPIV7Client(object):
                 {
                     "resourceType": "Patient",
                     "id": "1"
+                    "managingOrganization": {
+                        "reference": "Organization/2-11"  # Organization/2-11 is "NPC Internal testing"
+                    }
                 }
             ],
             "identifier": [

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/partner_api_client.py
@@ -304,7 +304,7 @@ class PartnerAPIV7Client(object):
             "contained": [
                 {
                     "resourceType": "Patient",
-                    "id": "1"
+                    "id": "1",
                     "managingOrganization": {
                         "reference": "Organization/2-11"  # Organization/2-11 is "NPC Internal testing"
                     }


### PR DESCRIPTION
To work around the issues we've been having with creating anonymous ServiceRequests I figured we could use the "NPC internal testing" organization (`Organization/2-11`), just to dump them somewhere.

