### PR TITLE
Adjust for Clarity 5.2 controls being booleans in database

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/create_discard_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/create_discard_samples.py
@@ -40,7 +40,7 @@ class Extension(BaseCreateSamplesExtension):
             name.append(specifier)
         name = "_".join(name)
         sample = Sample(sample_id=None, name=name, project=project)
-        sample.udf_map.force("Control", "No")
+        sample.udf_map.force("Control", "False")
 
         # Add KNM data:test_partner_user
         sample.udf_map.force("KNM data added at", timestamp)

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/import_samples.py
@@ -48,7 +48,7 @@ class Extension(BaseCreateSamplesExtension):
             name.append(specifier)
         name = "_".join(str(component) for component in name if component)
         sample = Sample(sample_id=None, name=name, project=project)
-        sample.udf_map.force("Control", "No")
+        sample.udf_map.force("Control", "False")
 
         # Add KNM data:test_partner_user
         sample.udf_map.force("KNM data added at", timestamp)
@@ -65,7 +65,7 @@ class Extension(BaseCreateSamplesExtension):
             name.append(specifier)
         name = "_".join(name)
         control = Sample(sample_id=None, name=name, project=project)
-        control.udf_map.force("Control", "Yes")
+        control.udf_map.force("Control", "True")
         control.udf_map.force("Control type", control_type_name)
         return control
 

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/report_results.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/report_results.py
@@ -11,7 +11,7 @@ from clarity_ext_scripts.covid.services.knm_service import KNMClientFromExtensio
 
 logger = logging.getLogger(__name__)
 
-UDF_TRUE = "Yes"
+UDF_TRUE = True
 
 
 class Extension(GeneralExtension):


### PR DESCRIPTION
Clarity 5.2 represents controls differently than earlier versions. We adjust the values stored in the DB to represent a sample as being a control sample from the text representations `"Yes"`/`"No"` to booleans `True` and `False`.