### PR TITLE
Add separate barcode generation script for RNA barcodes

### DIFF
--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_RNA.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_RNA.py
@@ -1,0 +1,42 @@
+import textwrap
+from clarity_ext.extensions import GeneralExtension
+
+
+class Extension(GeneralExtension):
+    """
+    Generate a set of two identical barcodes as zpl code for container in step.
+    The barcode encodes the name of the container.
+    """
+    def execute(self):
+        file_name = 'printfile.zpl'
+        containers = self.context.output_containers
+
+        barcode_template = [
+            "^XA",
+            "^LH0,0",
+              "^FO7,1",
+              "^BY1,",
+              "^BCN,48,N,",
+              "^FD{bc_data}",
+            "^FS",
+            "^FO7,55",
+              "^A0,20,25",
+              "^FB380,1,",
+              "^FD{label_text}",
+            "^FS",
+            "^XZ",
+        ]
+
+        container_barcodes = []
+        for c in containers:
+            barcode_data = c.name
+            container_barcodes.append(
+                ''.join(barcode_template).format(bc_data=barcode_data, label_text=barcode_data))
+
+        content = "\n".join(container_barcodes)
+        contents = ''.join(["\n", "${", content, content, "}$", "\n"])  # We need two copies
+        upload_packet = [(file_name, contents)]
+        self.context.file_service.upload_files("Print files", upload_packet)
+
+    def integration_tests(self):
+        yield "24-39294"

--- a/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_RNA.py
+++ b/clarity-ext-scripts/clarity_ext_scripts/covid/generate_barcode_list_RNA.py
@@ -14,7 +14,7 @@ class Extension(GeneralExtension):
         barcode_template = [
             "^XA",
             "^LH0,0",
-              "^FO7,1",
+            "^FO7,1",
               "^BY1,",
               "^BCN,48,N,",
               "^FD{bc_data}",


### PR DESCRIPTION
This new barcode generation script produces the expected results on all tested computers.

There was an issue with an earlier version of the script that included whitespace between all ZPL commands, which failed printing on some computers (don't know why).

Implementing this script requires small modifications in the Clarity workflows regarding how the EPP for the button is defined